### PR TITLE
Extract XcodeBuildMCP config to template, add doctor --fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ The script is interactive — it will ask what you want to install before making
 ```bash
 ./setup.sh                      # Interactive setup (pick components)
 ./setup.sh --all                # Install everything (minimal prompts)
-./setup.sh --doctor             # Diagnose installation health
-./setup.sh --configure-project  # Configure CLAUDE.local.md for a project
+./setup.sh doctor               # Diagnose installation health
+./setup.sh doctor --fix         # Diagnose and auto-fix issues
+./setup.sh configure-project    # Configure CLAUDE.local.md for a project
 ./setup.sh --help               # Show usage
 ```
 
@@ -110,7 +111,7 @@ If you cloned the repo:
 
 ```bash
 cd my-claude-ios-setup
-./setup.sh --configure-project
+./setup.sh configure-project
 ```
 
 If you used the one-line installer, clone and run:
@@ -118,7 +119,7 @@ If you used the one-line installer, clone and run:
 ```bash
 git clone https://github.com/bguidolim/my-claude-ios-setup.git
 cd my-claude-ios-setup
-./setup.sh --configure-project
+./setup.sh configure-project
 ```
 
 This auto-detects your Xcode project, asks for your name, generates `CLAUDE.local.md` with placeholders filled in, and creates `.xcodebuildmcp/config.yaml`.
@@ -228,7 +229,7 @@ xcrun sourcekit-lsp --help
 The script creates timestamped backups before modifying existing files:
 - `~/.claude/settings.json.backup.YYYYMMDD_HHMMSS`
 - `~/.claude.json.backup.YYYYMMDD_HHMMSS`
-- `<project>/CLAUDE.local.md.backup.YYYYMMDD_HHMMSS` (when `--configure-project` overwrites)
+- `<project>/CLAUDE.local.md.backup.YYYYMMDD_HHMMSS` (when `configure-project` overwrites)
 
 ## License
 

--- a/templates/xcodebuildmcp.yaml
+++ b/templates/xcodebuildmcp.yaml
@@ -1,0 +1,12 @@
+schemaVersion: 1
+enabledWorkflows:
+  - xcode-ide
+  - simulator
+  - ui-automation
+  - project-discovery
+  - utilities
+  - session-management
+sessionDefaults:
+  projectPath: ./__PROJECT__
+  suppressWarnings: false
+  platform: iOS


### PR DESCRIPTION
## Summary
- Move inline XcodeBuildMCP config to `templates/xcodebuildmcp.yaml` with `__PROJECT__` placeholder, matching the existing `CLAUDE.local.md` template pattern
- `configure-project` now detects config drift and offers to overwrite (with backup) instead of silently skipping
- Add `doctor --fix` flag that auto-fixes stale XcodeBuildMCP configs by regenerating from the template
- Switch CLI from `--doctor`/`--configure-project` flags to `doctor`/`configure-project` subcommands (old flags still work for backward compat)

## Test plan
- [x] Run `./setup.sh configure-project` on a project **without** `.xcodebuildmcp/config.yaml` — should create from template
- [x] Run `./setup.sh configure-project` on a project with an **up-to-date** config — should skip with "up to date" message
- [x] Run `./setup.sh configure-project` on a project with a **stale** config (e.g. `ui-testing`) — should warn and offer to overwrite
- [x] Run `./setup.sh doctor` on a project with stale config — should report missing/extra workflows
- [x] Run `./setup.sh doctor --fix` on a project with stale config — should auto-fix and show "(fixed)"
- [x] Verify `./setup.sh --doctor` and `./setup.sh --configure-project` still work (backward compat)