### PR TITLE
Add backup cleanup: end-of-run prompt and cleanup subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The script is interactive — it will ask what you want to install before making
 ./setup.sh doctor               # Diagnose installation health
 ./setup.sh doctor --fix         # Diagnose and auto-fix issues
 ./setup.sh configure-project    # Configure CLAUDE.local.md for a project
+./setup.sh cleanup              # Find and delete backup files
 ./setup.sh --help               # Show usage
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,7 @@
 #        ./setup.sh --all                 # Install everything (minimal prompts)
 #        ./setup.sh doctor [--fix]        # Diagnose installation health
 #        ./setup.sh configure-project     # Configure CLAUDE.local.md for a project
+#        ./setup.sh cleanup               # Find and delete backup files
 # =============================================================================
 
 set -euo pipefail
@@ -18,6 +19,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BACKUP_SUFFIX="backup.$(date +%Y%m%d_%H%M%S)"
+CREATED_BACKUPS=()   # Tracks backups created during this run
 CLAUDE_JSON="$HOME/.claude.json"
 CLAUDE_DIR="$HOME/.claude"
 CLAUDE_SETTINGS="$CLAUDE_DIR/settings.json"
@@ -160,6 +162,7 @@ backup_file() {
     if [[ -f "$file" ]]; then
         local backup="${file}.${BACKUP_SUFFIX}"
         cp "$file" "$backup"
+        CREATED_BACKUPS+=("$backup")
         info "Backed up $(basename "$file") → $(basename "$backup")"
     fi
 }
@@ -1391,6 +1394,94 @@ phase_summary_post() {
 }
 
 # ---------------------------------------------------------------------------
+# Backup cleanup
+# ---------------------------------------------------------------------------
+
+# Offer to delete backups created during this run
+prompt_cleanup_backups() {
+    if [[ ${#CREATED_BACKUPS[@]} -eq 0 ]]; then
+        return
+    fi
+
+    echo ""
+    header "🗑️  Backup Cleanup"
+    echo -e "  ${DIM}The following backup files were created during this run:${NC}"
+    echo ""
+    for f in "${CREATED_BACKUPS[@]}"; do
+        echo -e "    ${DIM}${f}${NC}"
+    done
+    echo ""
+    if ask_yn "Delete these backups?" "N"; then
+        for f in "${CREATED_BACKUPS[@]}"; do
+            rm -f "$f"
+        done
+        success "Deleted ${#CREATED_BACKUPS[@]} backup file(s)"
+    else
+        info "Backups kept. Run ./setup.sh cleanup to manage them later."
+    fi
+}
+
+# Find and manage all backup files from any previous run
+phase_cleanup() {
+    echo ""
+    echo -e "${BOLD}╔══════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BOLD}║   🗑️  Backup Cleanup                                    ║${NC}"
+    echo -e "${BOLD}╚══════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+
+    # Known backup locations
+    local -a search_dirs=(
+        "$HOME"                # ~/.claude.json.backup.*
+        "$CLAUDE_DIR"          # settings.json.backup.*
+    )
+
+    local -a found_backups=()
+
+    # Search known global locations
+    for dir in "${search_dirs[@]}"; do
+        if [[ -d "$dir" ]]; then
+            while IFS= read -r -d '' f; do
+                found_backups+=("$f")
+            done < <(find "$dir" -maxdepth 1 -name "*.backup.*" -type f -print0 2>/dev/null)
+        fi
+    done
+
+    # Search project directory (if in a project)
+    local project_dir="$PWD"
+    if ls "$project_dir"/*.xcodeproj >/dev/null 2>&1 || ls "$project_dir"/*.xcworkspace >/dev/null 2>&1; then
+        while IFS= read -r -d '' f; do
+            found_backups+=("$f")
+        done < <(find "$project_dir" -maxdepth 2 -name "*.backup.*" -type f -print0 2>/dev/null)
+    fi
+
+    if [[ ${#found_backups[@]} -eq 0 ]]; then
+        echo -e "  ${GREEN}No backup files found.${NC}"
+        echo ""
+        return
+    fi
+
+    # Group by timestamp
+    echo -e "  Found ${BOLD}${#found_backups[@]}${NC} backup file(s):"
+    echo ""
+    for f in "${found_backups[@]}"; do
+        local size
+        size=$(du -h "$f" 2>/dev/null | cut -f1 | tr -d ' ')
+        echo -e "    ${DIM}${f}${NC}  ${DIM}(${size})${NC}"
+    done
+    echo ""
+
+    if ask_yn "Delete all ${#found_backups[@]} backup file(s)?" "N"; then
+        for f in "${found_backups[@]}"; do
+            rm -f "$f"
+        done
+        success "Deleted ${#found_backups[@]} backup file(s)"
+    else
+        info "Backups kept."
+    fi
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
 # Doctor — Diagnose installation health
 # ---------------------------------------------------------------------------
 phase_doctor() {
@@ -1845,7 +1936,12 @@ case "${1:-}" in
         while ask_yn "Configure another project?" "N"; do
             configure_project
         done
+        prompt_cleanup_backups
         echo ""
+        exit 0
+        ;;
+    cleanup)
+        phase_cleanup
         exit 0
         ;;
     --help|-h)
@@ -1853,6 +1949,7 @@ case "${1:-}" in
         echo "       ./setup.sh --all                 # Install everything (minimal prompts)"
         echo "       ./setup.sh doctor [--fix]        # Diagnose installation health"
         echo "       ./setup.sh configure-project     # Configure CLAUDE.local.md for a project"
+        echo "       ./setup.sh cleanup               # Find and delete backup files"
         exit 0
         ;;
     "")
@@ -1870,6 +1967,7 @@ main() {
     phase_summary
     phase_install
     phase_summary_post
+    prompt_cleanup_backups
 }
 
 main


### PR DESCRIPTION
## Summary
- Track backup files created during each run in a `CREATED_BACKUPS` array
- At the end of interactive setup and `configure-project`, prompt the user to delete backups from this run (default: No)
- Add `./setup.sh cleanup` subcommand that scans known locations (`~/`, `~/.claude/`, current project dir) for `*.backup.*` files from any previous run, lists them with sizes, and offers to delete

## Test plan
- [x] Run `./setup.sh configure-project` on a project with an existing config — verify backup is created and cleanup prompt appears at the end
- [x] Answer "N" to cleanup prompt — verify backups are kept and hint about `cleanup` subcommand is shown
- [x] Answer "Y" to cleanup prompt — verify backups are deleted
- [x] Run `./setup.sh cleanup` from a project directory with leftover backups — verify they are found and listed
- [x] Run `./setup.sh cleanup` with no backups present — verify "No backup files found" message
- [x] Run `./setup.sh --help` — verify cleanup is listed