### PR TITLE
Add template placeholders, doctor freshness checks, and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Portable, interactive Bash setup script that configures Claude Code with MCP servers, plugins, skills, hooks, and settings optimized for iOS development on macOS. Installs to `~/.claude/` and configures per-project files via templates.
+
+## Commands
+
+```bash
+./setup.sh                      # Interactive setup (pick components)
+./setup.sh --all                # Install everything (minimal prompts)
+./setup.sh --dry-run            # Preview what would be installed
+./setup.sh --all --dry-run      # Preview full install
+./setup.sh doctor               # Diagnose installation health
+./setup.sh doctor --fix         # Diagnose and auto-fix issues
+./setup.sh configure-project    # Generate CLAUDE.local.md for a project
+./setup.sh cleanup              # Find and delete backup files
+```
+
+There are no tests, linting, or build steps — this is a pure Bash project.
+
+## Architecture
+
+### Entry points
+- `setup.sh` — main orchestrator; parses args, sources lib modules, dispatches to subcommands or runs the 5-phase install flow (welcome → selection → summary → install → post-summary)
+- `install.sh` — one-line web installer that clones to a temp dir and runs `setup.sh` with stdin from `/dev/tty`
+
+### Library modules (`lib/`)
+All sourced by `setup.sh` to share global state (flags, paths, color constants) without subshell overhead:
+- `utils.sh` — logging (`info`, `success`, `warn`, `error`, `header`, `step`), `ask_yn` prompts, `backup_file`, manifest tracking (SHA-256), `try_install`, brew path detection, `claude_cli` wrapper, `sed_escape`
+- `phases.sh` — the 5 installation phases; each phase function handles one stage
+- `configure.sh` — `configure_project()`: auto-detects Xcode projects, fills `__PLACEHOLDER__` tokens in templates, writes `CLAUDE.local.md` and `.xcodebuildmcp/config.yaml`
+- `doctor.sh` — `phase_doctor()`: health checks (deps, MCP servers, plugins, skills, hooks, file freshness via manifest)
+- `cleanup.sh` — backup file management (end-of-run prompt + `cleanup` subcommand)
+
+### Templates (`templates/`)
+- `CLAUDE.local.md` — per-project Claude instructions; placeholders: `__PROJECT__`, `__REPO_NAME__`, `__USER_NAME__`
+- `xcodebuildmcp.yaml` — XcodeBuildMCP workflow config
+
+### Installed artifacts
+- `config/settings.json` → `~/.claude/settings.json` (merged via jq)
+- `hooks/` → `~/.claude/hooks/` (session_start, continuous-learning-activator)
+- `skills/continuous-learning/` → `~/.claude/skills/continuous-learning/`
+- `commands/pr.md` → `~/.claude/commands/pr.md`
+
+## Bash Conventions
+
+- All scripts use `set -euo pipefail`; hooks use `trap 'exit 0' ERR` so failures don't crash Claude Code
+- Idempotent design: `*_needed` flags and `check_command` skip already-completed steps on re-runs
+- Global state via variables (`INSTALL_*`, `DRY_RUN`, `INSTALL_ALL`, tracking arrays `INSTALLED_ITEMS`, `SKIPPED_ITEMS`, `CREATED_BACKUPS`)
+- Template substitution uses `sed` with `sed_escape()` for safe path handling
+- JSON merging uses `jq` (array merge replaces rather than appends — see Serena memory `learning_jq_array_merge_silent_replacement`)
+- Dependencies are auto-resolved: selecting a component adds its required deps (e.g., Serena → uv, docs-mcp → Ollama)
+- `try_install` wraps installations: captures stderr, warns on failure, records in `SKIPPED_ITEMS`
+- Backups are always created before overwriting existing files
+
+## Key Design Decisions
+
+- **Sourced modules over subshells**: `lib/*.sh` are sourced (not executed) so they share the parent's global variables
+- **Subcommands over flags**: `doctor`, `configure-project`, `cleanup` are positional subcommands, not `--flags`
+- **Template-driven config**: templates use `__PLACEHOLDER__` tokens filled at runtime; `<!-- EDIT: ... -->` comments are stripped after substitution
+- **Two-tier backup cleanup**: prompt at end of run for fresh backups + dedicated `cleanup` subcommand for old ones
+- **Manifest tracking**: `~/.claude/.setup-manifest` stores SHA-256 hashes of source files for freshness checks in `doctor`

--- a/templates/CLAUDE.local.md
+++ b/templates/CLAUDE.local.md
@@ -7,7 +7,7 @@
 
 Before writing code, planning, or exploring — **always do these two steps first**:
 
-1. **Search the KB** — call `search_docs` with keywords relevant to the task (module, feature, concept). It indexes both documentation and Serena memories in a single semantic search. Try multiple keyword variations if needed.
+1. **Search the KB** — call `search_docs` with library `__REPO_NAME__` and keywords relevant to the task (module, feature, concept). It indexes both documentation and Serena memories in a single semantic search. Try multiple keyword variations if needed.
 2. **Read matching memories** — use Serena `read_memory` on any relevant results to get full context (architecture decisions, gotchas, patterns from past sessions).
 
 Only after these steps, proceed with Serena tools, Glob, or other discovery.
@@ -46,7 +46,7 @@ The `xcode-ide` workflow is enabled via `.xcodebuildmcp/config.yaml`, providing 
 
 ## Git & GitHub
 <!-- EDIT: Set your branch naming convention below -->
-- Branch naming: `<your-name>/{ticket-and-small-title}`
+- Branch naming: `__USER_NAME__/{ticket-and-small-title}`
 - **Never commit without being asked**
 - Use `gh` command for GitHub queries (auth already configured)
 


### PR DESCRIPTION
## Summary
- Add `__REPO_NAME__` placeholder to `CLAUDE.local.md` template so `search_docs` gets the correct docs-mcp-server library name (derived from git repo root, matching `session_start.sh` convention)
- Standardize all template placeholders to `__DOUBLE_UNDERSCORE__` pattern — rename `<your-name>` to `__USER_NAME__`
- Embed template hash in generated `CLAUDE.local.md`; doctor now checks for unsubstituted placeholders and template drift
- Default empty branch prefix to `feature` instead of keeping raw placeholder
- Add `CLAUDE.md` for repository guidance

## Test plan
- [x] Run `./setup.sh configure-project` — verify `__REPO_NAME__` is replaced with the repo folder name
- [x] Run `./setup.sh configure-project` and press Enter without typing a name — verify it defaults to `feature`
- [x] Run `./setup.sh doctor` from a configured project — verify CLAUDE.local.md passes
- [x] Modify `templates/CLAUDE.local.md` and run doctor again — verify it reports template drift
- [x] Run doctor on a project with a pre-existing CLAUDE.local.md (no hash stamp) — verify warning about missing hash