### PR TITLE
Improve overwrite and branch-naming prompts for clarity

### DIFF
--- a/lib/configure.sh
+++ b/lib/configure.sh
@@ -67,7 +67,8 @@ configure_project() {
     if [[ -n "$user_name" ]]; then
         echo -e "  Branch naming prefix: ${BOLD}${user_name}${NC}"
     else
-        echo -e "  ${BOLD}Your name for branch naming${NC} (e.g. ${DIM}bruno${NC}):"
+        echo -e "  ${BOLD}Your name for branch naming${NC} (e.g. ${DIM}bruno${NC} → ${DIM}bruno/ABC-123-fix-login${NC})"
+        echo -e "  Leave empty for ${DIM}feature/ABC-123-fix-login${NC}"
         echo -ne "  > "
         read -r user_name
         if [[ -z "$user_name" ]]; then
@@ -94,7 +95,7 @@ configure_project() {
     # --- Copy template ---
     local dest="$project_path/CLAUDE.local.md"
     if [[ -f "$dest" ]]; then
-        if ask_yn "CLAUDE.local.md already exists. Overwrite?" "N"; then
+        if ask_yn "CLAUDE.local.md already exists. Overwrite? (a backup will be created)" "N"; then
             backup_file "$dest"
         else
             warn "Skipped project configuration."
@@ -161,7 +162,7 @@ configure_project() {
             info "XcodeBuildMCP config is up to date — skipping"
         else
             warn "XcodeBuildMCP config differs from template"
-            if ask_yn "Overwrite .xcodebuildmcp/config.yaml with updated template?" "Y"; then
+            if ask_yn "Overwrite .xcodebuildmcp/config.yaml with updated template? (a backup will be created)" "Y"; then
                 backup_file "$xbm_config"
                 echo "$expected_config" > "$xbm_config"
                 success "Updated ${xbm_config}"

--- a/lib/phases.sh
+++ b/lib/phases.sh
@@ -69,9 +69,14 @@ phase_selection() {
 
         # Still need the API key and user name
         echo ""
-        echo -e "  ${BOLD}Your name${NC} (used for branch naming, e.g. ${DIM}bruno${NC}):"
+        echo -e "  ${BOLD}Your name for branch naming${NC} (e.g. ${DIM}bruno${NC} → ${DIM}bruno/ABC-123-fix-login${NC})"
+        echo -e "  Leave empty for ${DIM}feature/ABC-123-fix-login${NC}"
         echo -ne "  > "
         read -r USER_NAME
+        if [[ -z "$USER_NAME" ]]; then
+            USER_NAME='feature'
+            info "Defaulting branch prefix to: ${BOLD}${USER_NAME}${NC}"
+        fi
 
         echo ""
         local existing_pplx_key
@@ -261,11 +266,13 @@ phase_selection() {
     # === Ask for user name if needed by commands or project config ===
     if [[ $INSTALL_CMD_PR -eq 1 ]]; then
         echo ""
-        echo -e "  ${BOLD}Your name${NC} (used for branch naming in commands, e.g. ${DIM}bruno${NC}):"
+        echo -e "  ${BOLD}Your name for branch naming${NC} (e.g. ${DIM}bruno${NC} → ${DIM}bruno/ABC-123-fix-login${NC})"
+        echo -e "  Leave empty for ${DIM}feature/ABC-123-fix-login${NC}"
         echo -ne "  > "
         read -r USER_NAME
         if [[ -z "$USER_NAME" ]]; then
-            warn "No name entered — you can set it later in the command files."
+            USER_NAME='feature'
+            info "Defaulting branch prefix to: ${BOLD}${USER_NAME}${NC}"
         fi
     fi
 


### PR DESCRIPTION
## Summary
- Overwrite prompts (`CLAUDE.local.md`, `.xcodebuildmcp/config.yaml`) now mention that a backup will be created, so users know their data is safe before confirming
- Branch-naming prompts across all three flows (install-all, PR-command selection, configure-project) now show a concrete example of the resulting branch pattern (e.g. `bruno → bruno/ABC-123-fix-login`)
- Empty input on branch-naming prompts now consistently defaults to `feature` prefix with an info message, instead of warning or silently skipping

## Test plan
- [x] Run `./setup.sh --dry-run` — select "Install everything" and verify the branch-naming prompt shows the example pattern and "Leave empty for feature/…" hint
- [x] Run `./setup.sh --dry-run` — decline "Install everything", select only `/pr` command, and verify the branch-naming prompt matches
- [x] Run `./setup.sh configure-project` on a directory with an existing `CLAUDE.local.md` — verify the overwrite prompt says "(a backup will be created)"
- [x] Run `./setup.sh configure-project` — verify the branch-naming prompt shows the example and empty-default hint