### PR TITLE
Rename USER_NAME to BRANCH_PREFIX across codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ All sourced by `setup.sh` to share global state (flags, paths, color constants) 
 - `cleanup.sh` — backup file management (end-of-run prompt + `cleanup` subcommand)
 
 ### Templates (`templates/`)
-- `CLAUDE.local.md` — per-project Claude instructions; placeholders: `__PROJECT__`, `__REPO_NAME__`, `__USER_NAME__`
+- `CLAUDE.local.md` — per-project Claude instructions; placeholders: `__PROJECT__`, `__REPO_NAME__`, `__BRANCH_PREFIX__`
 - `xcodebuildmcp.yaml` — XcodeBuildMCP workflow config
 
 ### Installed artifacts

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -12,7 +12,7 @@ Arguments: $ARGUMENTS (optional — additional instructions for this PR, e.g. `t
    - Detect the repo's default branch: try `git symbolic-ref refs/remotes/origin/HEAD` first (local, no network), fall back to `gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'` if unset.
    - Run `git status` (never use `-uall`) and `git diff` (staged + unstaged) in parallel.
    - Run `git log <default-branch>..HEAD --oneline` to see existing commits on this branch.
-   - Extract the **ticket number** from the branch name (pattern: `__USER_NAME__/{ticket}-*` or `{ticket}-*`) or from commit messages. If not found, ask the user.
+   - Extract the **ticket number** from the branch name (pattern: `__BRANCH_PREFIX__/{ticket}-*` or `{ticket}-*`) or from commit messages. If not found, ask the user.
 
 3. **Stage and commit**:
    - Stage relevant files (prefer specific files over `git add -A`; never stage `.env` or credentials).

--- a/lib/configure.sh
+++ b/lib/configure.sh
@@ -62,21 +62,21 @@ configure_project() {
     fi
     echo ""
 
-    # --- Ask for user name (branch naming) — reuse if already provided ---
-    local user_name="$USER_NAME"
-    if [[ -n "$user_name" ]]; then
-        echo -e "  Branch naming prefix: ${BOLD}${user_name}${NC}"
+    # --- Ask for branch prefix — reuse if already provided ---
+    local branch_prefix="$BRANCH_PREFIX"
+    if [[ -n "$branch_prefix" ]]; then
+        echo -e "  Branch naming prefix: ${BOLD}${branch_prefix}${NC}"
     else
         echo -e "  ${BOLD}Your name for branch naming${NC} (e.g. ${DIM}bruno${NC} → ${DIM}bruno/ABC-123-fix-login${NC})"
         echo -e "  Leave empty for ${DIM}feature/ABC-123-fix-login${NC}"
         echo -ne "  > "
-        read -r user_name
-        if [[ -z "$user_name" ]]; then
-            user_name='feature'
-            info "Defaulting branch prefix to: ${BOLD}${user_name}${NC}"
+        read -r branch_prefix
+        if [[ -z "$branch_prefix" ]]; then
+            branch_prefix='feature'
+            info "Defaulting branch prefix to: ${BOLD}${branch_prefix}${NC}"
         else
             # Store globally for subsequent project configs
-            USER_NAME="$user_name"
+            BRANCH_PREFIX="$branch_prefix"
         fi
     fi
     echo ""
@@ -129,8 +129,8 @@ configure_project() {
     # 2. Branch naming: remove EDIT comment, replace placeholder
     sed -i '' '/<!-- EDIT: Set your branch naming convention below -->/d' "$dest"
     local safe_name
-    safe_name=$(sed_escape "$user_name")
-    sed -i '' "s/__USER_NAME__/${safe_name}/g" "$dest"
+    safe_name=$(sed_escape "$branch_prefix")
+    sed -i '' "s/__BRANCH_PREFIX__/${safe_name}/g" "$dest"
 
     # 3. CLAUDE.md symlink
     if [[ "$has_symlink" == true ]]; then
@@ -180,7 +180,7 @@ configure_project() {
     success "Project configured: ${project_path}"
     echo -e "    Xcode project:      ${BOLD}${xcode_project}${NC}"
     echo -e "    Docs library:       ${BOLD}${repo_name}${NC}"
-    echo -e "    Branch prefix:      ${BOLD}${user_name}/{ticket-and-small-title}${NC}"
+    echo -e "    Branch prefix:      ${BOLD}${branch_prefix}/{ticket-and-small-title}${NC}"
     echo -e "    XcodeBuildMCP:      ${BOLD}.xcodebuildmcp/config.yaml${NC}"
     if [[ "$has_symlink" == true ]]; then
         echo -e "    Symlink note:       ${GREEN}enabled${NC} (CLAUDE.md → AGENTS.md)"

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -240,8 +240,8 @@ phase_doctor() {
     echo -e "  ${DIM}──────────────────────────────────────────${NC}"
 
     if [[ -f "$HOME/.claude/commands/pr.md" ]]; then
-        if grep -q "__USER_NAME__" "$HOME/.claude/commands/pr.md" 2>/dev/null; then
-            doc_warn "/pr — installed but user name placeholder not replaced"
+        if grep -q "__BRANCH_PREFIX__" "$HOME/.claude/commands/pr.md" 2>/dev/null; then
+            doc_warn "/pr — installed but branch prefix placeholder not replaced"
         else
             doc_pass "/pr"
         fi
@@ -497,7 +497,7 @@ phase_doctor() {
             local claude_local_ok=true
 
             # Check for unsubstituted placeholders
-            if grep -qE '__REPO_NAME__|__PROJECT__|__USER_NAME__' "$project_dir/CLAUDE.local.md" 2>/dev/null; then
+            if grep -qE '__REPO_NAME__|__PROJECT__|__BRANCH_PREFIX__' "$project_dir/CLAUDE.local.md" 2>/dev/null; then
                 doc_warn "CLAUDE.local.md — has unsubstituted placeholders"
                 claude_local_ok=false
             fi

--- a/lib/fixes.sh
+++ b/lib/fixes.sh
@@ -85,16 +85,16 @@ fix_skill_learning() {
     manifest_record "skills/continuous-learning/references/templates.md"
 }
 
-# Copy /pr command and substitute user name placeholder
+# Copy /pr command and substitute branch prefix placeholder
 fix_cmd_pr() {
-    local user_name=${1:-}
+    local branch_prefix=${1:-}
     local commands_dir="$HOME/.claude/commands"
     mkdir -p "$commands_dir"
     cp "$SCRIPT_DIR/commands/pr.md" "$commands_dir/pr.md"
-    if [[ -n "$user_name" ]]; then
+    if [[ -n "$branch_prefix" ]]; then
         local safe_user
-        safe_user=$(sed_escape "$user_name")
-        sed -i '' "s/__USER_NAME__/${safe_user}/g" "$commands_dir/pr.md"
+        safe_user=$(sed_escape "$branch_prefix")
+        sed -i '' "s/__BRANCH_PREFIX__/${safe_user}/g" "$commands_dir/pr.md"
     fi
     manifest_record "commands/pr.md"
 }

--- a/lib/phases.sh
+++ b/lib/phases.sh
@@ -72,10 +72,10 @@ phase_selection() {
         echo -e "  ${BOLD}Your name for branch naming${NC} (e.g. ${DIM}bruno${NC} → ${DIM}bruno/ABC-123-fix-login${NC})"
         echo -e "  Leave empty for ${DIM}feature/ABC-123-fix-login${NC}"
         echo -ne "  > "
-        read -r USER_NAME
-        if [[ -z "$USER_NAME" ]]; then
-            USER_NAME='feature'
-            info "Defaulting branch prefix to: ${BOLD}${USER_NAME}${NC}"
+        read -r BRANCH_PREFIX
+        if [[ -z "$BRANCH_PREFIX" ]]; then
+            BRANCH_PREFIX='feature'
+            info "Defaulting branch prefix to: ${BOLD}${BRANCH_PREFIX}${NC}"
         fi
 
         echo ""
@@ -269,10 +269,10 @@ phase_selection() {
         echo -e "  ${BOLD}Your name for branch naming${NC} (e.g. ${DIM}bruno${NC} → ${DIM}bruno/ABC-123-fix-login${NC})"
         echo -e "  Leave empty for ${DIM}feature/ABC-123-fix-login${NC}"
         echo -ne "  > "
-        read -r USER_NAME
-        if [[ -z "$USER_NAME" ]]; then
-            USER_NAME='feature'
-            info "Defaulting branch prefix to: ${BOLD}${USER_NAME}${NC}"
+        read -r BRANCH_PREFIX
+        if [[ -z "$BRANCH_PREFIX" ]]; then
+            BRANCH_PREFIX='feature'
+            info "Defaulting branch prefix to: ${BOLD}${BRANCH_PREFIX}${NC}"
         fi
     fi
 
@@ -746,7 +746,7 @@ phase_install() {
         step $current_step $total_steps "Installing Commands"
 
         info "Installing /pr command..."
-        fix_cmd_pr "$USER_NAME"
+        fix_cmd_pr "$BRANCH_PREFIX"
         INSTALLED_ITEMS+=("Command: /pr")
         success "/pr command installed"
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -76,8 +76,8 @@ INSTALL_CMD_PR=0
 INSTALL_HOOKS=0
 INSTALL_SETTINGS=0
 
-# User identity (used in commands and project config)
-USER_NAME=""
+# Branch prefix (used in commands and project config, e.g. "bruno" or "feature")
+BRANCH_PREFIX=""
 
 # Full install mode (--all flag)
 INSTALL_ALL=0

--- a/templates/CLAUDE.local.md
+++ b/templates/CLAUDE.local.md
@@ -46,7 +46,7 @@ The `xcode-ide` workflow is enabled via `.xcodebuildmcp/config.yaml`, providing 
 
 ## Git & GitHub
 <!-- EDIT: Set your branch naming convention below -->
-- Branch naming: `__USER_NAME__/{ticket-and-small-title}`
+- Branch naming: `__BRANCH_PREFIX__/{ticket-and-small-title}`
 - **Never commit without being asked**
 - Use `gh` command for GitHub queries (auth already configured)
 


### PR DESCRIPTION
## Summary
- Rename global `USER_NAME` → `BRANCH_PREFIX` and local `user_name` → `branch_prefix` in all scripts
- Rename template placeholder `__USER_NAME__` → `__BRANCH_PREFIX__` in templates, sed substitutions, and doctor checks
- Update CLAUDE.md documentation to reflect the new placeholder name

Addresses review feedback from #7 — the variable name was misleading once empty input started defaulting to `feature` (which is not a user's name, but a branch prefix).

## Test plan
- [ ] `./setup.sh --dry-run` — verify prompts still render correctly
- [ ] `./setup.sh configure-project` — verify `__BRANCH_PREFIX__` is substituted in generated `CLAUDE.local.md`
- [ ] `./setup.sh doctor` — verify placeholder checks use `__BRANCH_PREFIX__`
- [ ] `grep -r USER_NAME .` — confirm zero remaining references (excluding `.git/`)