### PR TITLE
Respect user's global gitignore path via core.excludesFile

### DIFF
--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -345,19 +345,22 @@ phase_doctor() {
     echo ""
 
     # ===== Global Gitignore =====
-    echo -e "${BOLD}  Global Gitignore${NC} ${DIM}(~/.config/git/ignore)${NC}"
+    local git_ignore
+    git_ignore=$(resolve_git_excludes_file)
+    local git_ignore_display
+    git_ignore_display=$(echo "$git_ignore" | sed "s|^$HOME|~|")
+    echo -e "${BOLD}  Global Gitignore${NC} ${DIM}($git_ignore_display)${NC}"
     echo -e "  ${DIM}──────────────────────────────────────────${NC}"
 
-    local git_ignore="$HOME/.config/git/ignore"
     if [[ ! -f "$git_ignore" ]]; then
         if [[ "$doctor_fix" == "true" ]]; then
             if fix_gitignore_file; then
-                doc_fixed "~/.config/git/ignore created"
+                doc_fixed "$git_ignore_display created"
             else
-                doc_fix_failed "~/.config/git/ignore — could not create"
+                doc_fix_failed "$git_ignore_display — could not create"
             fi
         else
-            doc_fail "~/.config/git/ignore not found"
+            doc_fail "$git_ignore_display not found"
         fi
     fi
 

--- a/lib/phases.sh
+++ b/lib/phases.sh
@@ -784,7 +784,8 @@ phase_install() {
 
     # --- Global gitignore ---
     fix_gitignore_file
-    local git_ignore="$HOME/.config/git/ignore"
+    local git_ignore
+    git_ignore=$(resolve_git_excludes_file)
     local gitignore_entries=(".claude" "*.local.*" ".serena" ".xcodebuildmcp")
     local added_entries=()
 


### PR DESCRIPTION
## Context

The setup script hardcoded `~/.config/git/ignore` as the global gitignore path. Users who have `core.excludesFile` set to a different location (e.g., `~/.gitignore_global`) would see `.xcodebuildmcp` and other entries appear in `git diff` because the script was writing to the wrong file.

## Changes

- Add `resolve_git_excludes_file()` helper in `lib/fixes.sh` that queries `git config --global core.excludesFile`, handles tilde expansion, and falls back to Git's default `~/.config/git/ignore`
- Replace all hardcoded paths in `fix_gitignore_file()`, `fix_gitignore_entry()`, `phase_install()`, and `phase_doctor()`
- Doctor now dynamically displays the actual resolved gitignore path

## Testing Steps

- [x] Run `./setup.sh doctor` — verify the Global Gitignore section shows the correct path
- [x] Run `./setup.sh --all --dry-run` — verify no errors
- [x] Set `git config --global core.excludesFile ~/.gitignore_global` and run `./setup.sh doctor` — verify it checks the custom path
- [x] Unset with `git config --global --unset core.excludesFile` and verify fallback to `~/.config/git/ignore`