### PR TITLE
Fix v1→v2 migration detection with marker-based checks

### DIFF
--- a/Sources/mcs/Core/Manifest.swift
+++ b/Sources/mcs/Core/Manifest.swift
@@ -36,6 +36,11 @@ struct Manifest: Sendable {
         Array(entries.keys).sorted()
     }
 
+    /// Get the recorded hash for a source path (used for freshness comparison against bundled source).
+    func sourceHash(for relativePath: String) -> String? {
+        entries[relativePath]
+    }
+
     /// The SCRIPT_DIR recorded in the manifest (points to the source repo).
     var scriptDir: String? {
         metadata["SCRIPT_DIR"]

--- a/Sources/mcs/Doctor/DerivedDoctorChecks.swift
+++ b/Sources/mcs/Doctor/DerivedDoctorChecks.swift
@@ -19,7 +19,6 @@ extension ComponentDefinition {
                 name: displayName,
                 section: type.doctorSection,
                 command: package,
-                fixAction: "brew install \(package)",
                 isOptional: !isRequired
             )
 
@@ -106,6 +105,31 @@ struct SkillFreshnessCheck: DoctorCheck, Sendable {
         if !drifted.isEmpty {
             return .warn("drifted: \(drifted.joined(separator: ", ")) — run 'mcs install' to refresh")
         }
+
+        // Check if the bundled source has been updated since last install.
+        // This catches the case where manifest and installed match (both from a previous version)
+        // but the current binary ships with updated source.
+        if let resourceURL = Bundle.module.url(forResource: "Resources", withExtension: nil)?
+            .appendingPathComponent(skillSource),
+           FileManager.default.fileExists(atPath: resourceURL.path),
+           let sourceHashes = try? Manifest.directoryFileHashes(at: resourceURL) {
+            var sourceOutdated: [String] = []
+            for entry in sourceHashes {
+                let manifestPath = "\(skillSource)/\(entry.relativePath)"
+                if let manifestHash = manifest.sourceHash(for: manifestPath) {
+                    if manifestHash != entry.hash {
+                        sourceOutdated.append(entry.relativePath)
+                    }
+                } else {
+                    // New file in bundled source not in manifest — source has been updated
+                    sourceOutdated.append(entry.relativePath)
+                }
+            }
+            if !sourceOutdated.isEmpty {
+                return .warn("source updated in new mcs version — run 'mcs install' to refresh")
+            }
+        }
+
         return .pass("present, up to date")
     }
 

--- a/Sources/mcs/Doctor/DoctorRunner.swift
+++ b/Sources/mcs/Doctor/DoctorRunner.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 /// Orchestrates all doctor checks grouped by section, with optional fix mode.
+///
+/// **Scope of `--fix`**: Cleanup, migration, and trivial repairs only.
+/// Additive operations (install/register/copy) are deferred to `mcs install`
+/// because only install manages the manifest and records file hashes.
+/// See CoreDoctorChecks.swift header for the full responsibility boundary.
 struct DoctorRunner {
     let fixMode: Bool
     /// Explicit pack filter. If nil, uses packs recorded in the manifest.

--- a/Sources/mcs/Install/CoreComponents.swift
+++ b/Sources/mcs/Install/CoreComponents.swift
@@ -34,7 +34,7 @@ enum CoreComponents {
             command: "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
         ),
         supplementaryChecks: [
-            CommandCheck(name: "Homebrew", section: "Dependencies", command: "brew", fixAction: nil),
+            CommandCheck(name: "Homebrew", section: "Dependencies", command: "brew"),
         ]
     )
 
@@ -93,7 +93,7 @@ enum CoreComponents {
         isRequired: false,
         installAction: .shellCommand(command: "brew install --cask claude-code"),
         supplementaryChecks: [
-            CommandCheck(name: "Claude Code", section: "Dependencies", command: "claude", fixAction: nil),
+            CommandCheck(name: "Claude Code", section: "Dependencies", command: "claude"),
         ]
     )
 

--- a/Sources/mcs/Resources/commands/pr.md
+++ b/Sources/mcs/Resources/commands/pr.md
@@ -31,3 +31,5 @@ Arguments: $ARGUMENTS (optional — additional instructions for this PR, e.g. `t
 6. **Report** the PR URL.
 
 7. **Use** the skill continuous-learning.
+
+<!-- mcs:managed -->

--- a/Tests/MCSTests/CoreDoctorCheckTests.swift
+++ b/Tests/MCSTests/CoreDoctorCheckTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+
+@testable import mcs
+
+// MARK: - CommandFileCheck
+
+@Suite("CommandFileCheck")
+struct CommandFileCheckTests {
+    private func makeTempFile(content: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mcs-test-\(UUID().uuidString).md")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    @Test("pass when file has managed marker")
+    func passWithManagedMarker() throws {
+        let url = try makeTempFile(content: """
+            # My Command
+            Some content here.
+            <!-- mcs:managed -->
+            """)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let check = CommandFileCheck(name: "test", path: url)
+        let result = check.check()
+        if case .pass = result {
+            // expected
+        } else {
+            Issue.record("Expected .pass, got \(result)")
+        }
+    }
+
+    @Test("warn when file lacks managed marker (legacy v1 format)")
+    func warnWithoutManagedMarker() throws {
+        let url = try makeTempFile(content: """
+            # My Command
+            Some v1 content with no marker.
+            """)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let check = CommandFileCheck(name: "test", path: url)
+        let result = check.check()
+        if case .warn(let msg) = result {
+            #expect(msg.contains("legacy"))
+        } else {
+            Issue.record("Expected .warn, got \(result)")
+        }
+    }
+
+    @Test("warn when file has unreplaced placeholder")
+    func warnWithUnreplacedPlaceholder() throws {
+        let url = try makeTempFile(content: """
+            # My Command
+            Branch pattern: __BRANCH_PREFIX__/{ticket}-*
+            <!-- mcs:managed -->
+            """)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let check = CommandFileCheck(name: "test", path: url)
+        let result = check.check()
+        if case .warn(let msg) = result {
+            #expect(msg.contains("__BRANCH_PREFIX__"))
+        } else {
+            Issue.record("Expected .warn for unreplaced placeholder, got \(result)")
+        }
+    }
+
+    @Test("fail when file is missing")
+    func failWhenMissing() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nonexistent-\(UUID().uuidString).md")
+        let check = CommandFileCheck(name: "test", path: url)
+        let result = check.check()
+        if case .fail = result {
+            // expected
+        } else {
+            Issue.record("Expected .fail, got \(result)")
+        }
+    }
+
+    @Test("managed marker constant matches template marker")
+    func managedMarkerConstant() {
+        #expect(CommandFileCheck.managedMarker == "<!-- mcs:managed -->")
+    }
+}
+
+// MARK: - HookCheck
+
+@Suite("HookCheck")
+struct HookCheckTests {
+    @Test("extension marker constant matches hook template marker")
+    func extensionMarkerConstant() {
+        #expect(HookCheck.extensionMarker == "# --- mcs:hook-extensions ---")
+    }
+
+    @Test("deriveDoctorCheck generates HookCheck for copyHook action")
+    func derivedHookCheck() {
+        let component = ComponentDefinition(
+            id: "test.hook",
+            displayName: "test-hook.sh",
+            description: "test",
+            type: .hookFile,
+            packIdentifier: nil,
+            dependencies: [],
+            isRequired: true,
+            installAction: .copyHook(source: "hooks/test.sh", destination: "test.sh")
+        )
+        let check = component.deriveDoctorCheck()
+        #expect(check != nil)
+        #expect(check?.name == "test.sh")
+        #expect(check?.section == "Hooks")
+    }
+}

--- a/Tests/MCSTests/DerivedDoctorCheckTests.swift
+++ b/Tests/MCSTests/DerivedDoctorCheckTests.swift
@@ -165,8 +165,7 @@ struct DerivedDoctorCheckTests {
     @Test("allDoctorChecks returns derived + supplementary")
     func allDoctorChecksCombines() {
         let supplementary = CommandCheck(
-            name: "test", section: "Dependencies", command: "test", fixAction: nil
-        )
+            name: "test", section: "Dependencies", command: "test"        )
         let component = ComponentDefinition(
             id: "test.combined",
             displayName: "TestPkg",
@@ -186,8 +185,7 @@ struct DerivedDoctorCheckTests {
     @Test("shellCommand with supplementaryChecks returns only supplementary")
     func shellCommandWithSupplementary() {
         let supplementary = CommandCheck(
-            name: "brew", section: "Dependencies", command: "brew", fixAction: nil
-        )
+            name: "brew", section: "Dependencies", command: "brew"        )
         let component = ComponentDefinition(
             id: "test.shell",
             displayName: "test",


### PR DESCRIPTION
## Summary

- Detect v1 (bash installer) files by checking for v2 markers — hooks must contain `# --- mcs:hook-extensions ---`, commands must contain `<!-- mcs:managed -->`. Absence triggers reinstall on `mcs install`.
- Add bundled source comparison to `SkillFreshnessCheck` so updated skills in new binary versions are detected even when manifest-vs-installed hashes match.
- Simplify `doctor --fix` to cleanup/migration/permissions only. Additive operations (install/register/copy) are now exclusively `mcs install`'s responsibility to prevent inconsistent manifest state.

## Test plan

- [x] `swift build` succeeds
- [x] `swift test` passes (201 tests)
- [x] `mcs doctor` on a v1 machine flags legacy hooks (FAIL), commands (WARN), and updated skills (WARN)
- [x] `mcs doctor --fix` only fixes permissions, does not install/replace files
- [x] `mcs install` on a v1 machine replaces legacy hooks and commands, prompts for branch prefix
- [x] After install, continuous learning fragment is injected into session_start.sh