### PR TITLE
Add Core TechPack and fix mcs configure for any project

### DIFF
--- a/Sources/mcs/Commands/ConfigureCommand.swift
+++ b/Sources/mcs/Commands/ConfigureCommand.swift
@@ -63,15 +63,7 @@ struct ConfigureCommand: ParsableCommand {
             output.info("Project: \(projectPath.path)")
             output.info("Tech pack: \(resolvedPack.displayName)")
 
-            output.plain("")
-            output.plain("  Your name for branch naming (e.g. bruno \u{2192} bruno/ABC-123-fix-login)")
-            let branchPrefix = output.promptInline("Branch prefix", default: "feature")
-
-            try configurator.configure(
-                at: projectPath,
-                pack: resolvedPack,
-                branchPrefix: branchPrefix
-            )
+            try configurator.configure(at: projectPath, pack: resolvedPack)
 
             output.header("Done")
             output.info("Run 'mcs doctor' to verify configuration")

--- a/Sources/mcs/Packs/Core/CoreTechPack.swift
+++ b/Sources/mcs/Packs/Core/CoreTechPack.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Universal tech pack that works with any project regardless of technology.
+/// Core components (homebrew, node, plugins, hooks, etc.) remain global —
+/// this pack exists to enable `mcs configure` without a tech-specific pack.
+struct CoreTechPack: TechPack {
+    let identifier = "core"
+    let displayName = "Core"
+    let description = "Universal Claude Code setup — works with any project"
+
+    // Core components are installed globally via CoreComponents.all, not via this pack.
+    let components: [ComponentDefinition] = []
+    let hookContributions: [HookContribution] = []
+    let gitignoreEntries: [String] = []
+    var supplementaryDoctorChecks: [any DoctorCheck] { [] }
+
+    /// Template contributions — conditional based on installed features.
+    /// The symlink note is project-specific and handled by ProjectConfigurator,
+    /// not here (we don't have the project path in this context).
+    var templates: [TemplateContribution] {
+        var result: [TemplateContribution] = []
+
+        if Self.isContinuousLearningInstalled() {
+            result.append(TemplateContribution(
+                sectionIdentifier: "continuous-learning",
+                templateContent: CoreTemplates.continuousLearningSection,
+                placeholders: ["__REPO_NAME__"]
+            ))
+        }
+
+        return result
+    }
+
+    func configureProject(at path: URL, context: ProjectConfigContext) throws {
+        // No pack-specific project configuration for core.
+    }
+
+    // MARK: - Feature Detection
+
+    /// Check whether the continuous learning feature is installed by querying
+    /// the manifest — the system's source of truth for installed components.
+    static func isContinuousLearningInstalled() -> Bool {
+        let env = Environment()
+        let manifest = Manifest(path: env.setupManifest)
+        return manifest.trackedPaths.contains("hooks/continuous-learning-activator.sh")
+    }
+}

--- a/Sources/mcs/Packs/Core/CoreTemplates.swift
+++ b/Sources/mcs/Packs/Core/CoreTemplates.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Template content contributed by the Core tech pack.
+enum CoreTemplates {
+    /// Symlink note — included when CLAUDE.md is a symlink in the project.
+    /// Prevents Claude from redundantly re-reading the original file.
+    static let symlinkNote = """
+        > **Note:** `CLAUDE.md` is a symlink — its content is already loaded at session start. \
+        Do not re-read the original file via tool calls.
+        """
+
+    /// KB search mandate — only injected when continuous learning is installed.
+    /// Instructs Claude to search the project knowledge base before starting work.
+    static let continuousLearningSection = """
+        ## MANDATORY — Before Starting Any Task
+
+        Before writing code, planning, or exploring — **always search the knowledge base first**:
+
+        1. **Search the KB** — call `search_docs` with library `__REPO_NAME__` and keywords \
+        relevant to the task. Try multiple keyword variations if needed.
+        2. **Read matching memories** — review any relevant results for full context \
+        (architecture decisions, gotchas, patterns from past sessions).
+
+        Only after these steps, proceed with discovery and implementation.
+        """
+}

--- a/Sources/mcs/TechPack/TechPack.swift
+++ b/Sources/mcs/TechPack/TechPack.swift
@@ -3,7 +3,6 @@ import Foundation
 /// Context provided to tech packs during project configuration
 struct ProjectConfigContext: Sendable {
     let projectPath: URL
-    let branchPrefix: String
     let repoName: String
 }
 

--- a/Sources/mcs/TechPack/TechPackRegistry.swift
+++ b/Sources/mcs/TechPack/TechPackRegistry.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Registry of all available tech packs.
 /// Immutable after initialization — all packs are compiled-in.
 struct TechPackRegistry: Sendable {
-    static let shared = TechPackRegistry(packs: [IOSTechPack()])
+    static let shared = TechPackRegistry(packs: [CoreTechPack(), IOSTechPack()])
 
     private let packs: [any TechPack]
 

--- a/Tests/MCSTests/CoreTechPackTests.swift
+++ b/Tests/MCSTests/CoreTechPackTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import mcs
+
+@Suite("CoreTechPack")
+struct CoreTechPackTests {
+    @Test("Core pack has correct identifier")
+    func packIdentifier() {
+        let pack = CoreTechPack()
+        #expect(pack.identifier == "core")
+    }
+
+    @Test("Core pack has correct display name")
+    func packDisplayName() {
+        let pack = CoreTechPack()
+        #expect(pack.displayName == "Core")
+    }
+
+    @Test("Core pack has no components")
+    func noComponents() {
+        let pack = CoreTechPack()
+        #expect(pack.components.isEmpty)
+    }
+
+    @Test("Core pack has no hook contributions")
+    func noHooks() {
+        let pack = CoreTechPack()
+        #expect(pack.hookContributions.isEmpty)
+    }
+
+    @Test("Core pack has no gitignore entries")
+    func noGitignore() {
+        let pack = CoreTechPack()
+        #expect(pack.gitignoreEntries.isEmpty)
+    }
+
+    @Test("Core pack has no supplementary doctor checks")
+    func noDoctorChecks() {
+        let pack = CoreTechPack()
+        #expect(pack.supplementaryDoctorChecks.isEmpty)
+    }
+
+    @Test("configureProject is a no-op")
+    func configureNoOp() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mcs-core-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let pack = CoreTechPack()
+        let context = ProjectConfigContext(projectPath: tmpDir, repoName: "test")
+        try pack.configureProject(at: tmpDir, context: context)
+
+        let contents = try FileManager.default.contentsOfDirectory(atPath: tmpDir.path)
+        #expect(contents.isEmpty)
+    }
+
+    @Test("Registry contains core pack")
+    func registryContainsCore() {
+        let registry = TechPackRegistry.shared
+        let core = registry.pack(for: "core")
+        #expect(core != nil)
+        #expect(core?.displayName == "Core")
+    }
+
+    @Test("Registry lists core before iOS")
+    func registryOrder() {
+        let packs = TechPackRegistry.shared.availablePacks
+        let identifiers = packs.map(\.identifier)
+        #expect(identifiers.count >= 2)
+        #expect(identifiers.first == "core")
+        #expect(identifiers.contains("ios"))
+    }
+}
+
+@Suite("CoreTemplates")
+struct CoreTemplatesTests {
+    @Test("Symlink note contains relevant content")
+    func symlinkNote() {
+        #expect(CoreTemplates.symlinkNote.contains("symlink"))
+        #expect(CoreTemplates.symlinkNote.contains("CLAUDE.md"))
+    }
+
+    @Test("Continuous learning section contains REPO_NAME placeholder")
+    func continuousLearningPlaceholder() {
+        #expect(CoreTemplates.continuousLearningSection.contains("__REPO_NAME__"))
+    }
+
+    @Test("Continuous learning section mentions search_docs")
+    func continuousLearningContent() {
+        #expect(CoreTemplates.continuousLearningSection.contains("search_docs"))
+    }
+}


### PR DESCRIPTION
## Summary

- **Core TechPack**: New universal, technology-agnostic tech pack that enables `mcs configure` for any project (Python, Rust, etc.) without requiring a tech-specific pack like iOS
- **Fix broken configure**: `mcs configure` crashed since the v2 rewrite because it tried to load `Resources/templates/core/CLAUDE.local.md` which never existed — templates now live in Swift code (`CoreTemplates.swift`), consistent with `IOSTemplates.swift`
- **Conditional CLAUDE.local.md**: File is only created when there's meaningful content — symlink note (when `CLAUDE.md` is a symlink) and KB search mandate (when continuous learning is installed per manifest)
- **Remove branch prefix prompt**: No longer used in any template; removed from `ProjectConfigContext` and both configure flows

## Changes

| File | Change |
|---|---|
| `Sources/mcs/Packs/Core/CoreTemplates.swift` | New — template string constants (symlink note, KB search mandate) |
| `Sources/mcs/Packs/Core/CoreTechPack.swift` | New — TechPack conformance with manifest-based continuous learning detection |
| `Sources/mcs/TechPack/TechPackRegistry.swift` | Register CoreTechPack (first in selection list) |
| `Sources/mcs/TechPack/TechPack.swift` | Remove `branchPrefix` from `ProjectConfigContext` |
| `Sources/mcs/Install/ProjectConfigurator.swift` | Refactor: remove resource loading, new `gatherTemplateContributions()` with symlink detection, conditional CLAUDE.local.md, extracted helper methods |
| `Sources/mcs/Commands/ConfigureCommand.swift` | Remove branch prefix prompt from explicit `--pack` flow |
| `Tests/MCSTests/CoreTechPackTests.swift` | New — 12 tests for CoreTechPack, CoreTemplates, and registry integration |

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 213 tests pass (12 new)
- [x] `mcs configure` — shows Core and iOS in selection, no branch prefix prompt
- [x] `mcs configure --pack core` — works for non-iOS projects
- [x] `mcs configure --pack core` with no symlink + no continuous learning → skips CLAUDE.local.md
- [x] `mcs configure --pack ios` — core + iOS sections composed correctly
- [x] `mcs doctor` — no regressions