### PR TITLE
Fix configure to use global gitignore instead of project .gitignore

### DIFF
--- a/Sources/mcs/Core/GitignoreManager.swift
+++ b/Sources/mcs/Core/GitignoreManager.swift
@@ -10,6 +10,7 @@ struct GitignoreManager: Sendable {
         Constants.FileNames.claudeDirectory,
         "*.local.*",
         "\(Constants.FileNames.claudeDirectory)/memories/",
+        "\(Constants.FileNames.claudeDirectory)/\(Constants.FileNames.mcsProject)",
     ]
 
     /// Resolve the global gitignore file path.

--- a/Sources/mcs/Install/CoreComponents.swift
+++ b/Sources/mcs/Install/CoreComponents.swift
@@ -244,12 +244,12 @@ enum CoreComponents {
     static let gitignoreCore = ComponentDefinition(
         id: "core.gitignore",
         displayName: "Global gitignore",
-        description: "Add .claude, *.local.*, .claude/memories/ to global gitignore",
+        description: "Add .claude, *.local.*, .claude/memories/, .claude/.mcs-project to global gitignore",
         type: .configuration,
         packIdentifier: nil,
         dependencies: [],
         isRequired: true,
-        installAction: .gitignoreEntries(entries: [Constants.FileNames.claudeDirectory, "*.local.*", "\(Constants.FileNames.claudeDirectory)/memories/"])
+        installAction: .gitignoreEntries(entries: [Constants.FileNames.claudeDirectory, "*.local.*", "\(Constants.FileNames.claudeDirectory)/memories/", "\(Constants.FileNames.claudeDirectory)/\(Constants.FileNames.mcsProject)"])
     )
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

- `mcs configure` was appending `.claude/memories/` and `.claude/.mcs-project` to the project's tracked `.gitignore`, dirtying the working tree and forcing developers to commit tool-specific entries
- Changed `ProjectConfigurator` to delegate to `GitignoreManager`, which resolves the user's global excludes file via `git config --global core.excludesFile` (matching the v1.0.0 behavior)
- Added `.claude/.mcs-project` to `GitignoreManager.coreEntries` and the `gitignoreCore` install action

## Test plan

- [x] Run `mcs configure` in a project — verify the project `.gitignore` is NOT modified
- [x] Check global gitignore (path from `git config --global core.excludesFile`) contains `.claude/.mcs-project`
- [x] Run `mcs doctor` — verify global gitignore check passes with all entries
- [x] `swift test` — all 213 tests pass