### PR TITLE
Include resource bundle in release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          BINARY_PATH=$(swift build -c release --arch arm64 --arch x86_64 --show-bin-path)/mcs
+          BIN_DIR=$(swift build -c release --arch arm64 --arch x86_64 --show-bin-path)
           TARBALL="mcs-${TAG_NAME}-macos-universal.tar.gz"
-          tar -czf "${TARBALL}" -C "$(dirname "${BINARY_PATH}")" mcs
+          tar -czf "${TARBALL}" -C "${BIN_DIR}" mcs my-claude-setup_mcs.bundle
           shasum -a 256 "${TARBALL}" > SHA256SUMS
           echo "TARBALL=${TARBALL}" >> "$GITHUB_ENV"
 
@@ -61,8 +61,10 @@ jobs:
             license "MIT"
 
             def install
-              bin.install "mcs"
-              bin.install_symlink "mcs" => "my-claude-setup"
+              libexec.install "mcs"
+              libexec.install "my-claude-setup_mcs.bundle"
+              bin.install_symlink libexec/"mcs"
+              bin.install_symlink libexec/"mcs" => "my-claude-setup"
             end
 
             test do


### PR DESCRIPTION
## Summary

- Include `my-claude-setup_mcs.bundle` in the release tarball alongside the `mcs` binary so `Bundle.module` can find resources (hooks, skills, settings, commands) at runtime
- Update generated Homebrew formula to use `libexec` for co-locating binary and bundle, with symlinks from `bin/`

## Context

SwiftPM produces a resource bundle (`my-claude-setup_mcs.bundle`) alongside the binary during build. The release workflow was only packaging the bare `mcs` executable into the tarball, causing `Bundle.module` resource lookups to fail on Homebrew installations. The `libexec` pattern is the standard Homebrew convention for tools that need ancillary files next to the binary.

## Testing Steps

- [x] Build locally: `swift build -c release --arch arm64 --arch x86_64`
- [x] Verify bundle exists next to binary in `--show-bin-path` output
- [x] Create test tarball and confirm it contains both `mcs` and `my-claude-setup_mcs.bundle`
- [x] Simulate Homebrew `libexec` layout with symlink and run `mcs doctor` to verify resources load