### PR TITLE
Add conditional Serena code-editing instructions to CLAUDE.local.md

### DIFF
--- a/Sources/mcs/Install/Installer.swift
+++ b/Sources/mcs/Install/Installer.swift
@@ -280,6 +280,7 @@ struct Installer {
             if isAlreadyInstalled(component) {
                 skippedItems.append("\(component.displayName) (already installed)")
                 output.dimmed("Already installed, skipping")
+                manifest.recordInstalledComponent(component.id)
                 continue
             }
 
@@ -290,6 +291,7 @@ struct Installer {
             )
             if success {
                 installedItems.append(component.displayName)
+                manifest.recordInstalledComponent(component.id)
                 output.success("\(component.displayName) installed")
             } else {
                 skippedItems.append("\(component.displayName) (failed)")

--- a/Sources/mcs/Install/ProjectConfigurator.swift
+++ b/Sources/mcs/Install/ProjectConfigurator.swift
@@ -224,7 +224,7 @@ struct ProjectConfigurator {
     /// - If `.serena/memories` exists as real directory → copy files, delete, create symlink.
     /// - If `.serena/memories` doesn't exist → create `.serena/` if needed, create symlink.
     private func ensureSerenaMemoriesSymlink(at projectPath: URL) {
-        guard isSerenaMCPInstalled() else { return }
+        guard CoreTechPack.isSerenaInstalled() else { return }
 
         let fm = FileManager.default
         let serenaMemories = projectPath
@@ -291,17 +291,6 @@ struct ProjectConfigurator {
         } catch {
             output.warn("Could not create symlink: \(error.localizedDescription)")
         }
-    }
-
-    private func isSerenaMCPInstalled() -> Bool {
-        let claudeJSON = environment.claudeJSON
-        guard let data = try? Data(contentsOf: claudeJSON),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let mcpServers = json[Constants.JSONKeys.mcpServers] as? [String: Any]
-        else {
-            return false
-        }
-        return mcpServers[Constants.Serena.mcpServerName] != nil
     }
 
     // MARK: - Gitignore

--- a/Sources/mcs/Packs/Core/CoreTemplates.swift
+++ b/Sources/mcs/Packs/Core/CoreTemplates.swift
@@ -9,6 +9,26 @@ enum CoreTemplates {
         Do not re-read the original file via tool calls.
         """
 
+    /// Serena code-editing preference — only injected when Serena MCP server is installed.
+    /// Instructs Claude to prefer Serena's symbolic tools for code editing tasks.
+    /// Tool names are sourced from Serena's MCP interface; update if Serena's API changes.
+    static let serenaSection = """
+        ## Code Editing — Prefer Serena's Symbolic Tools
+
+        When Serena's tools are available and the language is supported, **prefer Serena's \
+        symbolic code-editing tools** over the built-in file tools:
+
+        - **Navigation**: Use `find_symbol`, `find_referencing_symbols`, and `get_symbols_overview` \
+        instead of Grep/Glob for locating code.
+        - **Editing**: Use `replace_symbol_body`, `insert_after_symbol`, `insert_before_symbol`, \
+        and `rename_symbol` instead of Edit for modifying code.
+        - **Context**: Use `get_symbols_overview` to understand file structure before making changes.
+        - **Before removing or renaming** any symbol, verify it is unused via `find_referencing_symbols`.
+
+        Serena auto-detects the project's languages. For files or languages Serena does not support, \
+        fall back to the standard Read, Edit, Grep, and Glob tools.
+        """
+
     /// KB search mandate — only injected when continuous learning is installed.
     /// Instructs Claude to search the project knowledge base before starting work.
     static let continuousLearningSection = """

--- a/Tests/MCSTests/CoreTechPackTests.swift
+++ b/Tests/MCSTests/CoreTechPackTests.swift
@@ -91,4 +91,18 @@ struct CoreTemplatesTests {
     func continuousLearningContent() {
         #expect(CoreTemplates.continuousLearningSection.contains("search_docs"))
     }
+
+    @Test("Serena section mentions key symbolic tools")
+    func serenaContent() {
+        #expect(CoreTemplates.serenaSection.contains("replace_symbol_body"))
+        #expect(CoreTemplates.serenaSection.contains("find_symbol"))
+        #expect(CoreTemplates.serenaSection.contains("get_symbols_overview"))
+        #expect(CoreTemplates.serenaSection.contains("find_referencing_symbols"))
+    }
+
+    @Test("Serena section has no unreplaced placeholders")
+    func serenaNoPlaceholders() {
+        let unreplaced = TemplateEngine.findUnreplacedPlaceholders(in: CoreTemplates.serenaSection)
+        #expect(unreplaced.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `INSTALLED_COMPONENTS` metadata key to the manifest, tracking all component IDs installed by `mcs install` for ownership visibility
- When Serena is installed, `mcs configure` now injects a language-generic "prefer Serena symbolic tools" section into `CLAUDE.local.md`
- Refactors `ProjectConfigurator.isSerenaMCPInstalled()` to use manifest-based detection instead of parsing `claude.json`

## Context

The old v1.0.0 template had a hardcoded "Swift Code Operations via Serena" section that was lost during the tech-pack refactor. This restores equivalent functionality in a language-generic way — Serena auto-detects 30+ languages, so the instructions say "prefer" rather than "never use alternatives."

The `INSTALLED_COMPONENTS` key makes the manifest a complete ownership record of what `mcs` manages, complementing the existing file hash and pack tracking.

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (222 tests, including 4 new ones)
- [x] Run `mcs install --all`, verify `~/.claude/.mcs-manifest` contains `INSTALLED_COMPONENTS=...`
- [x] Run `mcs configure` in a project, verify `CLAUDE.local.md` has `<!-- mcs:begin serena -->` section
- [x] Run `mcs configure` without Serena installed, verify no Serena section appears