### PR TITLE
Add /commit command and simplify /pr command

### DIFF
--- a/Sources/mcs/Install/CoreComponents.swift
+++ b/Sources/mcs/Install/CoreComponents.swift
@@ -15,7 +15,7 @@ enum CoreComponents {
         // Hooks
         hookSessionStart, hookContinuousLearning,
         // Commands
-        commandPR,
+        commandPR, commandCommit,
         // Configuration
         settingsMerge, gitignoreCore,
     ]
@@ -224,6 +224,21 @@ enum CoreComponents {
         installAction: .copyCommand(
             source: "commands/pr.md",
             destination: "pr.md",
+            placeholders: ["BRANCH_PREFIX": "feature"]
+        )
+    )
+
+    static let commandCommit = ComponentDefinition(
+        id: "core.command.commit",
+        displayName: "/commit command",
+        description: "Stages, commits, and pushes changes without PR creation",
+        type: .command,
+        packIdentifier: nil,
+        dependencies: [],
+        isRequired: false,
+        installAction: .copyCommand(
+            source: "commands/commit.md",
+            destination: "commit.md",
             placeholders: ["BRANCH_PREFIX": "feature"]
         )
     )

--- a/Sources/mcs/Install/Installer.swift
+++ b/Sources/mcs/Install/Installer.swift
@@ -846,7 +846,7 @@ struct Installer {
     // MARK: - Interactive Selection Helpers
 
     private func askBranchPrefix(_ state: inout SelectionState) {
-        if state.isSelected("core.command.pr") {
+        if state.isSelected("core.command.pr") || state.isSelected("core.command.commit") {
             output.plain("")
             output.plain("  Your name for branch naming (e.g. bruno \u{2192} bruno/ABC-123-fix-login)")
             state.branchPrefix = output.promptInline("Branch prefix", default: "feature")

--- a/Sources/mcs/Resources/commands/commit.md
+++ b/Sources/mcs/Resources/commands/commit.md
@@ -1,0 +1,23 @@
+# Commit and Push
+
+Stage, commit, and push changes. No PR creation. This is a **git-only workflow** — never build or test.
+
+## Branch naming convention
+
+Branches follow the pattern: `__BRANCH_PREFIX__/{ticket}-short-description` (e.g. `__BRANCH_PREFIX__/ABC-123-fix-login`).
+
+## Steps
+
+1. **Analyze changes**:
+   - Run `git status` (never use `-uall`) and `git diff` (staged + unstaged) in parallel.
+   - Extract the **ticket number** from the branch name (pattern: `__BRANCH_PREFIX__/{ticket}-*` or `{ticket}-*`). If not found, ask the user.
+
+2. **Stage and commit**:
+   - Stage relevant files (prefer specific files over `git add -A`; never stage `.env` or credentials).
+   - Describe **what** changed based on the **actual code diff** — the conversation may contain reverted attempts, bugs, or dead ends that don't reflect the final result. Use the conversation for **context and rationale** (the *why*), but never describe changes that aren't in the diff.
+   - Commit message format: one-line summary + max 3 bullet points describing actual changes. Use HEREDOC for the message.
+   - If there are no changes to commit, say so and stop.
+
+3. **Push** the current branch with `-u` flag if needed.
+
+<!-- mcs:managed -->

--- a/Sources/mcs/Resources/commands/pr.md
+++ b/Sources/mcs/Resources/commands/pr.md
@@ -4,15 +4,18 @@ Automate the full commit-push-PR pipeline. This is a **git-only workflow** — n
 
 Arguments: $ARGUMENTS (optional — additional instructions for this PR, e.g. `target develop` or `skip commit`)
 
+## Branch naming convention
+
+Branches follow the pattern: `__BRANCH_PREFIX__/{ticket}-short-description` (e.g. `__BRANCH_PREFIX__/ABC-123-fix-login`).
+
 ## Steps
 
 1. **Check KB/memory** for any relevant PR conventions or context related to the current branch/feature.
 
 2. **Analyze changes**:
-   - Detect the repo's default branch: try `git symbolic-ref refs/remotes/origin/HEAD` first (local, no network), fall back to `gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'` if unset.
    - Run `git status` (never use `-uall`) and `git diff` (staged + unstaged) in parallel.
-   - Run `git log <default-branch>..HEAD --oneline` to see existing commits on this branch.
-   - Extract the **ticket number** from the branch name (pattern: `__BRANCH_PREFIX__/{ticket}-*` or `{ticket}-*`) or from commit messages. If not found, ask the user.
+   - Run `git log origin/HEAD..HEAD --oneline` to see commits on this branch (if `origin/HEAD` is not set, fall back to `git log --oneline`).
+   - Extract the **ticket number** from the branch name (pattern: `__BRANCH_PREFIX__/{ticket}-*` or `{ticket}-*`). If not found, ask the user.
 
 3. **Stage and commit**:
    - Stage relevant files (prefer specific files over `git add -A`; never stage `.env` or credentials).


### PR DESCRIPTION
## Summary

- **New `/commit` command** — stages, commits, and pushes changes without PR creation, managed by `mcs` with doctor checks and versioning
- **Simplified `/pr` command** — replaced default branch detection (`git symbolic-ref` + `gh repo view` fallback) with `origin/HEAD..HEAD`; added branch naming convention section
- **Aligned both commands** — shared structure for branch naming, ticket extraction, staging rules, diff-driven descriptions, and commit message format

## Changes

| File | Change |
|------|--------|
| `Sources/mcs/Resources/commands/commit.md` | New `/commit` command resource with `<!-- mcs:managed -->` marker |
| `Sources/mcs/Resources/commands/pr.md` | Removed default branch detection, added `## Branch naming convention` section, uses `origin/HEAD..HEAD` for git log |
| `Sources/mcs/Install/CoreComponents.swift` | Added `commandCommit` component definition with `BRANCH_PREFIX` placeholder, registered in `all` array |
| `Sources/mcs/Install/Installer.swift` | `askBranchPrefix` now triggers for both `core.command.pr` and `core.command.commit` |

## Design notes

- No changes needed to `DerivedDoctorChecks`, `Package.swift`, or `Installer.copyCommand()` — existing infrastructure handles the new component automatically
- Doctor check auto-generated from `.copyCommand` action via `deriveDoctorCheck()`
- `origin/HEAD` is a symbolic ref set by `git clone`; fallback to unlimited `git log` if not set

## Test plan

- [x] `swift build` — clean compilation
- [x] `swift test` — 213 tests pass across 24 suites
- [x] `mcs install --dry-run` — `/commit command` appears in installation plan
- [x] `mcs doctor` — `/commit command` appears under Commands section