### PR TITLE
Extract shared ComponentExecutor from Installer and PackInstaller

### DIFF
--- a/Sources/mcs/Install/ComponentExecutor.swift
+++ b/Sources/mcs/Install/ComponentExecutor.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// Shared component installation logic used by both `Installer` (mcs install)
+/// and `PackInstaller` (mcs configure). Eliminates duplication and ensures
+/// consistent behavior across install paths.
+struct ComponentExecutor {
+    let environment: Environment
+    let output: CLIOutput
+    let shell: ShellRunner
+    var backup: Backup
+
+    // MARK: - Brew Packages
+
+    /// Install a Homebrew package, or confirm it's already available.
+    func installBrewPackage(_ package: String) -> Bool {
+        if shell.commandExists(package) { return true }
+        let brew = Homebrew(shell: shell, environment: environment)
+        guard brew.isInstalled else {
+            output.warn("Homebrew not found, cannot install \(package)")
+            return false
+        }
+        if brew.isPackageInstalled(package) { return true }
+        let result = brew.install(package)
+        if !result.succeeded {
+            output.warn(String(result.stderr.prefix(200)))
+        }
+        return result.succeeded
+    }
+
+    // MARK: - MCP Servers
+
+    /// Register an MCP server via the Claude CLI.
+    func installMCPServer(_ config: MCPServerConfig) -> Bool {
+        guard shell.commandExists(Constants.CLI.claudeCommand) else {
+            output.warn("Claude Code CLI not found, skipping MCP server")
+            return false
+        }
+        let claude = ClaudeIntegration(shell: shell)
+
+        var args: [String] = []
+        for (key, value) in config.env.sorted(by: { $0.key < $1.key }) {
+            args.append(contentsOf: ["-e", "\(key)=\(value)"])
+        }
+        if config.command == "http" {
+            args.append(contentsOf: ["--transport", "http"])
+            args.append(contentsOf: config.args)
+        } else {
+            args.append("--")
+            args.append(config.command)
+            args.append(contentsOf: config.args)
+        }
+
+        let result = claude.mcpAdd(name: config.name, arguments: args)
+        return result.succeeded
+    }
+
+    // MARK: - Plugins
+
+    /// Install a plugin via the Claude CLI.
+    func installPlugin(_ fullName: String) -> Bool {
+        guard shell.commandExists(Constants.CLI.claudeCommand) else {
+            output.warn("Claude Code CLI not found, skipping plugin")
+            return false
+        }
+        let claude = ClaudeIntegration(shell: shell)
+        let result = claude.pluginInstall(fullName: fullName)
+        return result.succeeded
+    }
+
+    // MARK: - Gitignore
+
+    /// Add entries to the global gitignore.
+    func addGitignoreEntries(_ entries: [String]) -> Bool {
+        let manager = GitignoreManager(shell: shell)
+        do {
+            for entry in entries {
+                try manager.addEntry(entry)
+            }
+            return true
+        } catch {
+            output.dimmed(error.localizedDescription)
+            return false
+        }
+    }
+
+    // MARK: - Post-Install
+
+    /// Run post-install steps for specific components (e.g., start services, pull models).
+    func postInstall(_ component: ComponentDefinition) {
+        switch component.id {
+        case "core.ollama":
+            let ollama = OllamaService(shell: shell, environment: environment)
+            if ollama.isRunning() {
+                output.dimmed("Ollama already running")
+            } else {
+                output.dimmed("Starting Ollama...")
+                if !ollama.start() {
+                    output.warn("Could not start Ollama automatically.")
+                    output.warn("Start it manually with 'ollama serve' or open the Ollama app, then re-run.")
+                }
+            }
+            output.dimmed("Pulling \(Constants.Ollama.embeddingModel) model...")
+            if let result = ollama.pullEmbeddingModelIfNeeded(), !result.succeeded {
+                output.warn("Could not pull \(Constants.Ollama.embeddingModel): \(result.stderr)")
+            }
+        default:
+            break
+        }
+    }
+
+    // MARK: - Pack Post-Processing
+
+    /// Inject a pack's hook contributions into installed hook files using section markers.
+    mutating func injectHookContributions(from pack: any TechPack) {
+        for contribution in pack.hookContributions {
+            let hookFile = environment.hooksDirectory
+                .appendingPathComponent(contribution.hookName + ".sh")
+            HookInjector.inject(
+                fragment: contribution.scriptFragment,
+                identifier: pack.identifier,
+                into: hookFile,
+                backup: &backup,
+                output: output
+            )
+        }
+    }
+
+    /// Add a pack's gitignore entries to the global gitignore.
+    func addPackGitignoreEntries(from pack: any TechPack) {
+        guard !pack.gitignoreEntries.isEmpty else { return }
+        let manager = GitignoreManager(shell: shell)
+        for entry in pack.gitignoreEntries {
+            do {
+                try manager.addEntry(entry)
+            } catch {
+                output.warn("Failed to add gitignore entry '\(entry)': \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Already-Installed Detection
+
+    /// Check if a component is already installed using the same derived + supplementary
+    /// doctor checks used by `mcs doctor`, ensuring install and doctor always use
+    /// the same detection logic.
+    static func isAlreadyInstalled(_ component: ComponentDefinition) -> Bool {
+        // Idempotent actions: always re-run
+        switch component.installAction {
+        case .settingsMerge, .gitignoreEntries:
+            return false
+        default:
+            break
+        }
+
+        // Try derived check (auto-generated from installAction)
+        if let check = component.deriveDoctorCheck() {
+            if case .pass = check.check() { return true }
+        }
+
+        // Try supplementary checks (component-specific extras)
+        for check in component.supplementaryChecks {
+            if case .pass = check.check() { return true }
+        }
+
+        return false
+    }
+}

--- a/Sources/mcs/Install/Installer.swift
+++ b/Sources/mcs/Install/Installer.swift
@@ -394,6 +394,15 @@ struct Installer {
 
     // MARK: - Component Installation
 
+    private var executor: ComponentExecutor {
+        ComponentExecutor(
+            environment: environment,
+            output: output,
+            shell: shell,
+            backup: backup
+        )
+    }
+
     private mutating func installComponent(
         _ component: ComponentDefinition,
         state: SelectionState,
@@ -401,9 +410,9 @@ struct Installer {
     ) -> Bool {
         switch component.installAction {
         case .brewInstall(let package):
-            let success = installBrewPackage(package)
+            let success = executor.installBrewPackage(package)
             if success {
-                postInstall(component)
+                executor.postInstall(component)
             }
             return success
 
@@ -415,10 +424,10 @@ struct Installer {
             return result.succeeded
 
         case .mcpServer(let config):
-            return installMCPServer(config)
+            return executor.installMCPServer(config)
 
         case .plugin(let name):
-            return installPlugin(name)
+            return executor.installPlugin(name)
 
         case .copySkill(let source, let destination):
             return copySkill(source: source, destination: destination, manifest: &manifest)
@@ -439,63 +448,8 @@ struct Installer {
             return mergeSettings()
 
         case .gitignoreEntries(let entries):
-            return addGitignoreEntries(entries)
+            return executor.addGitignoreEntries(entries)
         }
-    }
-
-    private func installBrewPackage(_ package: String) -> Bool {
-        // Already available (installed via any method — Homebrew, macOS app, nvm, etc.)
-        if shell.commandExists(package) {
-            return true
-        }
-        let brew = Homebrew(shell: shell, environment: environment)
-        guard brew.isInstalled else {
-            output.warn("Homebrew not found, cannot install \(package)")
-            return false
-        }
-        if brew.isPackageInstalled(package) {
-            return true
-        }
-        let result = brew.install(package)
-        if !result.succeeded {
-            output.warn(String(result.stderr.prefix(200)))
-        }
-        return result.succeeded
-    }
-
-    private func installMCPServer(_ config: MCPServerConfig) -> Bool {
-        guard shell.commandExists(Constants.CLI.claudeCommand) else {
-            output.warn("Claude Code CLI not found, skipping MCP server")
-            return false
-        }
-        let claude = ClaudeIntegration(shell: shell)
-
-        // Build arguments
-        var args: [String] = []
-        for (key, value) in config.env.sorted(by: { $0.key < $1.key }) {
-            args.append(contentsOf: ["-e", "\(key)=\(value)"])
-        }
-        if config.command == "http" {
-            args.append(contentsOf: ["--transport", "http"])
-            args.append(contentsOf: config.args)
-        } else {
-            args.append("--")
-            args.append(config.command)
-            args.append(contentsOf: config.args)
-        }
-
-        let result = claude.mcpAdd(name: config.name, arguments: args)
-        return result.succeeded
-    }
-
-    private func installPlugin(_ fullName: String) -> Bool {
-        guard shell.commandExists(Constants.CLI.claudeCommand) else {
-            output.warn("Claude Code CLI not found, skipping plugin")
-            return false
-        }
-        let claude = ClaudeIntegration(shell: shell)
-        let result = claude.pluginInstall(fullName: fullName)
-        return result.succeeded
     }
 
     /// Resolve a bundled resource path relative to Resources/.
@@ -702,100 +656,20 @@ struct Installer {
         }
     }
 
-    /// Run post-install steps for specific components (e.g., start services, pull models).
-    private func postInstall(_ component: ComponentDefinition) {
-        switch component.id {
-        case "core.ollama":
-            let ollama = OllamaService(shell: shell, environment: environment)
-            if ollama.isRunning() {
-                output.dimmed("Ollama already running")
-            } else {
-                output.dimmed("Starting Ollama...")
-                if !ollama.start() {
-                    output.warn("Could not start Ollama automatically.")
-                    output.warn("Start it manually with 'ollama serve' or open the Ollama app, then re-run.")
-                }
-            }
-            output.dimmed("Pulling \(Constants.Ollama.embeddingModel) model...")
-            if let result = ollama.pullEmbeddingModelIfNeeded(), !result.succeeded {
-                output.warn("Could not pull \(Constants.Ollama.embeddingModel): \(result.stderr)")
-            }
-        default:
-            break
-        }
-    }
-
-    private func addGitignoreEntries(_ entries: [String]) -> Bool {
-        let manager = GitignoreManager(shell: shell)
-        do {
-            for entry in entries {
-                try manager.addEntry(entry)
-            }
-            return true
-        } catch {
-            output.dimmed(error.localizedDescription)
-            return false
-        }
-    }
-
     // MARK: - Pack Post-Processing
 
-    /// Inject a pack's hook contributions into installed hook files using section markers.
     private mutating func injectHookContributions(from pack: any TechPack) {
-        for contribution in pack.hookContributions {
-            let hookFile = environment.hooksDirectory
-                .appendingPathComponent(contribution.hookName + ".sh")
-            HookInjector.inject(
-                fragment: contribution.scriptFragment,
-                identifier: pack.identifier,
-                into: hookFile,
-                backup: &backup,
-                output: output
-            )
-        }
+        var exec = executor
+        exec.injectHookContributions(from: pack)
+        backup = exec.backup
     }
 
-    /// Add a pack's gitignore entries to the global gitignore.
     private func addPackGitignoreEntries(from pack: any TechPack) {
-        guard !pack.gitignoreEntries.isEmpty else { return }
-        let manager = GitignoreManager(shell: shell)
-        for entry in pack.gitignoreEntries {
-            do {
-                try manager.addEntry(entry)
-            } catch {
-                output.warn("Failed to add gitignore entry '\(entry)': \(error.localizedDescription)")
-            }
-        }
+        executor.addPackGitignoreEntries(from: pack)
     }
 
-    // MARK: - Already-installed detection
-
-    /// Check if a component is already installed.
-    /// Delegates to the same derived + supplementary doctor checks used by `mcs doctor`,
-    /// ensuring install and doctor always use the same detection logic.
-    /// Returns true if ANY check (derived OR supplementary) passes — this means
-    /// a component with a passing supplementary check is considered installed even
-    /// if its derived check fails.
     private func isAlreadyInstalled(_ component: ComponentDefinition) -> Bool {
-        // Idempotent actions: always re-run
-        switch component.installAction {
-        case .settingsMerge, .gitignoreEntries:
-            return false
-        default:
-            break
-        }
-
-        // Try derived check (auto-generated from installAction)
-        if let check = component.deriveDoctorCheck() {
-            if case .pass = check.check() { return true }
-        }
-
-        // Try supplementary checks (component-specific extras)
-        for check in component.supplementaryChecks {
-            if case .pass = check.check() { return true }
-        }
-
-        return false
+        ComponentExecutor.isAlreadyInstalled(component)
     }
 
     // MARK: - Continuous Learning Post-Processing

--- a/Sources/mcs/Install/PackInstaller.swift
+++ b/Sources/mcs/Install/PackInstaller.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// Installs pack components with dependency resolution.
-/// Shared between `Installer` (mcs install) and `ConfigureCommand` (mcs configure).
+/// Used by `ConfigureCommand` (mcs configure) to auto-install missing pack dependencies.
+/// Delegates to `ComponentExecutor` for shared install logic, ensuring consistent
+/// behavior with `Installer` (mcs install).
 struct PackInstaller {
     let environment: Environment
     let output: CLIOutput
@@ -18,6 +20,15 @@ struct PackInstaller {
         self.output = output
         self.shell = shell
         self.backup = backup
+    }
+
+    private var executor: ComponentExecutor {
+        ComponentExecutor(
+            environment: environment,
+            output: output,
+            shell: shell,
+            backup: backup
+        )
     }
 
     /// Install missing components for a pack. Returns true if all succeeded.
@@ -42,7 +53,9 @@ struct PackInstaller {
         }
 
         // Filter to components that aren't already installed
-        let missing = plan.orderedComponents.filter { !isAlreadyInstalled($0) }
+        let missing = plan.orderedComponents.filter {
+            !ComponentExecutor.isAlreadyInstalled($0)
+        }
 
         if missing.isEmpty {
             output.dimmed("All \(pack.displayName) components already installed")
@@ -76,8 +89,10 @@ struct PackInstaller {
         }
 
         // Post-processing: hook contributions and gitignore
-        injectHookContributions(from: pack)
-        addPackGitignoreEntries(from: pack)
+        var exec = executor
+        exec.injectHookContributions(from: pack)
+        exec.addPackGitignoreEntries(from: pack)
+        backup = exec.backup
 
         return allSucceeded
     }
@@ -85,11 +100,13 @@ struct PackInstaller {
     // MARK: - Component Installation
 
     private func installComponent(_ component: ComponentDefinition) -> Bool {
+        let exec = executor
+
         switch component.installAction {
         case .brewInstall(let package):
-            let success = installBrewPackage(package)
+            let success = exec.installBrewPackage(package)
             if success {
-                postInstall(component)
+                exec.postInstall(component)
             }
             return success
 
@@ -101,178 +118,17 @@ struct PackInstaller {
             return result.succeeded
 
         case .mcpServer(let config):
-            return installMCPServer(config)
+            return exec.installMCPServer(config)
 
         case .plugin(let name):
-            return installPlugin(name)
+            return exec.installPlugin(name)
 
         case .gitignoreEntries(let entries):
-            return addGitignoreEntries(entries)
+            return exec.addGitignoreEntries(entries)
 
         case .copySkill, .copyHook, .copyCommand, .settingsMerge:
             // These are core-only actions, not used by pack components
             return true
-        }
-    }
-
-    private func installBrewPackage(_ package: String) -> Bool {
-        if shell.commandExists(package) { return true }
-        let brew = Homebrew(shell: shell, environment: environment)
-        guard brew.isInstalled else {
-            output.warn("Homebrew not found, cannot install \(package)")
-            return false
-        }
-        if brew.isPackageInstalled(package) { return true }
-        let result = brew.install(package)
-        if !result.succeeded {
-            output.warn(String(result.stderr.prefix(200)))
-        }
-        return result.succeeded
-    }
-
-    private func installMCPServer(_ config: MCPServerConfig) -> Bool {
-        guard shell.commandExists(Constants.CLI.claudeCommand) else {
-            output.warn("Claude Code CLI not found, skipping MCP server")
-            return false
-        }
-        let claude = ClaudeIntegration(shell: shell)
-
-        var args: [String] = []
-        for (key, value) in config.env.sorted(by: { $0.key < $1.key }) {
-            args.append(contentsOf: ["-e", "\(key)=\(value)"])
-        }
-        if config.command == "http" {
-            args.append(contentsOf: ["--transport", "http"])
-            args.append(contentsOf: config.args)
-        } else {
-            args.append("--")
-            args.append(config.command)
-            args.append(contentsOf: config.args)
-        }
-
-        let result = claude.mcpAdd(name: config.name, arguments: args)
-        return result.succeeded
-    }
-
-    private func installPlugin(_ fullName: String) -> Bool {
-        guard shell.commandExists(Constants.CLI.claudeCommand) else {
-            output.warn("Claude Code CLI not found, skipping plugin")
-            return false
-        }
-        let claude = ClaudeIntegration(shell: shell)
-        let result = claude.pluginInstall(fullName: fullName)
-        return result.succeeded
-    }
-
-    private func addGitignoreEntries(_ entries: [String]) -> Bool {
-        let manager = GitignoreManager(shell: shell)
-        do {
-            for entry in entries {
-                try manager.addEntry(entry)
-            }
-            return true
-        } catch {
-            output.dimmed(error.localizedDescription)
-            return false
-        }
-    }
-
-    private func postInstall(_ component: ComponentDefinition) {
-        switch component.id {
-        case "core.ollama":
-            let ollama = OllamaService(shell: shell, environment: environment)
-            if ollama.isRunning() {
-                output.dimmed("Ollama already running")
-            } else {
-                output.dimmed("Starting Ollama...")
-                if !ollama.start() {
-                    output.warn("Could not start Ollama automatically.")
-                    output.warn("Start it manually with 'ollama serve' or open the Ollama app, then re-run.")
-                }
-            }
-            output.dimmed("Pulling \(Constants.Ollama.embeddingModel) model...")
-            if let result = ollama.pullEmbeddingModelIfNeeded(), !result.succeeded {
-                output.warn("Could not pull \(Constants.Ollama.embeddingModel): \(result.stderr)")
-            }
-        default:
-            break
-        }
-    }
-
-    // MARK: - Already-installed detection
-
-    func isAlreadyInstalled(_ component: ComponentDefinition) -> Bool {
-        let fm = FileManager.default
-
-        switch component.installAction {
-        case .brewInstall(let package):
-            if shell.commandExists(package) { return true }
-            return Homebrew(shell: shell, environment: environment).isPackageInstalled(package)
-
-        case .mcpServer(let config):
-            guard fm.fileExists(atPath: environment.claudeJSON.path) else { return false }
-            do {
-                let data = try Data(contentsOf: environment.claudeJSON)
-                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-                let servers = json?[Constants.JSONKeys.mcpServers] as? [String: Any]
-                return servers?[config.name] != nil
-            } catch {
-                return false
-            }
-
-        case .plugin(let name):
-            guard fm.fileExists(atPath: environment.claudeSettings.path) else { return false }
-            do {
-                let settings = try Settings.load(from: environment.claudeSettings)
-                return settings.enabledPlugins?[name] == true
-            } catch {
-                return false
-            }
-
-        case .shellCommand:
-            // Handle components installed via shell commands that have a verifiable binary
-            switch component.id {
-            case "core.homebrew":
-                return shell.commandExists("brew")
-            case "core.claude-code":
-                return shell.commandExists(Constants.CLI.claudeCommand)
-            default:
-                return false
-            }
-
-        case .gitignoreEntries:
-            return false // Idempotent
-
-        case .copySkill, .copyHook, .copyCommand, .settingsMerge:
-            return false
-        }
-    }
-
-    // MARK: - Pack Post-Processing
-
-    private mutating func injectHookContributions(from pack: any TechPack) {
-        for contribution in pack.hookContributions {
-            let hookFile = environment.hooksDirectory
-                .appendingPathComponent(contribution.hookName + ".sh")
-            HookInjector.inject(
-                fragment: contribution.scriptFragment,
-                identifier: pack.identifier,
-                into: hookFile,
-                backup: &backup,
-                output: output
-            )
-        }
-    }
-
-    private func addPackGitignoreEntries(from pack: any TechPack) {
-        guard !pack.gitignoreEntries.isEmpty else { return }
-        let manager = GitignoreManager(shell: shell)
-        for entry in pack.gitignoreEntries {
-            do {
-                try manager.addEntry(entry)
-            } catch {
-                output.warn("Failed to add gitignore entry '\(entry)': \(error.localizedDescription)")
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extracts 7 duplicated methods from `Installer` and `PackInstaller` into a shared `ComponentExecutor`
- **Critically**: Replaces `PackInstaller`'s divergent inline `isAlreadyInstalled()` with the shared `deriveDoctorCheck()`-based detection, ensuring `mcs install` and `mcs configure` use identical logic
- Net reduction: 212 insertions, 315 deletions (-103 lines)

## Problem
`Installer.swift` and `PackInstaller.swift` had near-identical implementations of `installBrewPackage`, `installMCPServer`, `installPlugin`, `postInstall`, `addGitignoreEntries`, `injectHookContributions`, and `addPackGitignoreEntries`. Worse, their `isAlreadyInstalled()` logic was **completely different** — Installer delegated to doctor checks while PackInstaller had its own switch-case, meaning the two could give different answers for the same component.

## Test plan
- [x] `swift build` succeeds
- [x] All 222 tests pass
- [x] Manual: `mcs install --all` + `mcs configure` produce consistent results
- [x] Manual: `mcs doctor` reports no false positives after install