### PR TITLE
Preserve file hash entries during manifest re-initialization

### DIFF
--- a/Sources/mcs/Core/Manifest.swift
+++ b/Sources/mcs/Core/Manifest.swift
@@ -82,14 +82,17 @@ struct Manifest: Sendable {
     }
 
     /// Initialize the manifest with a source directory header.
+    /// Preserves existing file hash entries so that skipped (already-installed)
+    /// components retain their hash tracking across re-installs. Components that
+    /// are re-installed will overwrite their entries with fresh hashes.
     mutating func initialize(sourceDirectory: String) {
         let previousPacks = metadata["INSTALLED_PACKS"]
         metadata["SCRIPT_DIR"] = sourceDirectory
         // INSTALLED_COMPONENTS is cleared because it reflects the exact set chosen
         // during each install run (components can be deselected).
         // INSTALLED_PACKS is preserved because pack membership is additive across runs.
+        // File hash entries are preserved so skipped components keep their tracking.
         metadata.removeValue(forKey: "INSTALLED_COMPONENTS")
-        entries = [:]
         // Preserve installed packs across re-initialization
         if let previousPacks {
             metadata["INSTALLED_PACKS"] = previousPacks


### PR DESCRIPTION
## Summary
- Removes `entries = [:]` from `Manifest.initialize()` so file hashes survive re-initialization
- Adds test verifying file hash preservation across re-init
- Prevents doctor freshness check degradation after repeated `mcs install` runs

## Problem
Running `mcs install` a second time cleared all file hash entries via `Manifest.initialize()`. Skipped (already-installed) components didn't re-record their hashes, so the manifest became incomplete. `ManifestFreshnessCheck` would then report "no manifest found" for those files.

## Test plan
- [x] `swift build` succeeds
- [x] All 223 tests pass (222 existing + 1 new)
- [x] Manual: `mcs install --all` twice, then `mcs doctor` shows full hash tracking