### PR TITLE
Validate section marker pairing to prevent silent content loss

### DIFF
--- a/Sources/mcs/Install/ProjectConfigurator.swift
+++ b/Sources/mcs/Install/ProjectConfigurator.swift
@@ -159,6 +159,15 @@ struct ProjectConfigurator {
         let composed: String
         if fm.fileExists(atPath: claudeLocalPath.path) {
             let existingContent = try String(contentsOf: claudeLocalPath, encoding: .utf8)
+
+            // Warn about unpaired section markers that would prevent safe updates
+            let unpaired = TemplateComposer.unpairedSections(in: existingContent)
+            if !unpaired.isEmpty {
+                output.warn("Unpaired section markers in CLAUDE.local.md: \(unpaired.joined(separator: ", "))")
+                output.warn("Sections with missing end markers will not be updated to prevent data loss.")
+                output.warn("Add the missing end markers manually, then re-run mcs configure.")
+            }
+
             let userContent = TemplateComposer.extractUserContent(from: existingContent)
 
             // Update core section


### PR DESCRIPTION
## Summary
- Adds `TemplateComposer.unpairedSections(in:)` to detect missing end markers
- `replaceSection()` now returns original content unchanged when target section has unpaired marker
- `ProjectConfigurator` warns users about unpaired markers with guidance to fix
- 4 new tests covering unpaired detection and safety behavior

## Problem
If a user accidentally deleted an `<!-- mcs:end core -->` marker from their CLAUDE.local.md, the next `mcs configure` would silently drop all content after that begin marker — including user content and other pack sections. This was because `replaceSection()` set `skipUntilEnd = true` and never found the end marker, so all subsequent lines were discarded.

## Test plan
- [x] `swift build` succeeds
- [x] All 226 tests pass (222 existing + 4 new)
- [x] Manual: Edit CLAUDE.local.md to remove an end marker, run `mcs configure`, verify warning and content preservation