### PR TITLE
Add v2 launch documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ mcs doctor --pack ios            # Only check a specific pack
 mcs configure [path]             # Generate CLAUDE.local.md (core + installed packs)
 mcs configure --pack ios         # Explicitly apply a pack's templates
 mcs cleanup                      # Find and delete backup files
+mcs cleanup --force              # Delete backups without confirmation
 ```
 
 ## Architecture
@@ -32,53 +33,78 @@ mcs cleanup                      # Find and delete backup files
 ### Swift Package Structure
 - **Package.swift** — swift-tools-version: 6.0, macOS 13+, deps: swift-argument-parser, Yams
 - **Sources/mcs/** — main executable target
+- **Tests/MCSTests/** — test target
+
+### Entry Point
+- `CLI.swift` — `@main` struct, `MCSVersion.current`, subcommand registration
 
 ### Core (`Sources/mcs/Core/`)
+- `Constants.swift` — centralized string constants (file names, CLI paths, Ollama config, hooks, Serena, JSON keys, plugins)
 - `Environment.swift` — paths, arch detection, brew path, shell RC
-- `CLIOutput.swift` — ANSI colors, logging, prompts, doctor summary
+- `CLIOutput.swift` — ANSI colors, logging, prompts, multi-select, doctor summary
 - `ShellRunner.swift` — Process execution wrapper
-- `Settings.swift` — Codable model, deep-merge (replaces jq)
-- `Manifest.swift` — SHA-256 tracking via CryptoKit, per-file directory hashing
-- `Backup.swift` — timestamped backups before file writes
-- `GitignoreManager.swift` — global gitignore management
-- `ClaudeIntegration.swift` — `claude mcp add`, `claude plugin install`
+- `Settings.swift` — Codable model for `settings.json`, deep-merge (replaces jq)
+- `SettingsOwnership.swift` — sidecar file tracking which settings keys mcs manages, stale key detection
+- `Manifest.swift` — SHA-256 tracking via CryptoKit, per-file directory hashing, installed component/pack tracking
+- `Backup.swift` — timestamped backups before file writes, backup discovery and deletion
+- `GitignoreManager.swift` — global gitignore management, core entry list
+- `ClaudeIntegration.swift` — `claude mcp add/remove`, `claude plugin install/remove`
 - `Homebrew.swift` — brew detection, package install
+- `HookInjector.swift` — section-marker-based fragment injection into hook files
+- `OllamaService.swift` — Ollama daemon management, model pull, health check
 - `ProjectDetector.swift` — walk-up project root detection (`.git/` or `CLAUDE.local.md`)
-- `ProjectState.swift` — per-project `.mcs-project` state (configured packs, version)
+- `ProjectState.swift` — per-project `.claude/.mcs-project` state (configured packs, version)
+- `MCSError.swift` — error types for the CLI
 
 ### TechPack System (`Sources/mcs/TechPack/`)
-- `TechPack.swift` — protocol for tech packs (components, templates, hooks, doctor checks)
-- `Component.swift` — ComponentDefinition with install actions
-- `TechPackRegistry.swift` — registry of available packs
-- `DependencyResolver.swift` — topological sort of component dependencies
+- `TechPack.swift` — protocol for tech packs (components, templates, hooks, doctor checks, migrations)
+- `Component.swift` — ComponentDefinition with install actions, ComponentType enum
+- `TechPackRegistry.swift` — registry of available packs, filtering by installed state
+- `DependencyResolver.swift` — topological sort of component dependencies with cycle detection
 
 ### Doctor (`Sources/mcs/Doctor/`)
 - `DoctorRunner.swift` — 7-layer check orchestration with project-aware pack resolution
-- `CoreDoctorChecks.swift` — check structs (CommandCheck, MCPServerCheck, PluginCheck, etc.)
-- `DerivedDoctorChecks.swift` — `deriveDoctorCheck()` extension on ComponentDefinition + SkillFreshnessCheck
-- `ProjectDoctorChecks.swift` — project-scoped checks (version, Serena migration, state file)
+- `CoreDoctorChecks.swift` — check structs (CommandCheck, MCPServerCheck, PluginCheck, HookCheck, SettingsCheck, GitignoreCheck, DeprecatedMCPServerCheck, DeprecatedPluginCheck, HookContributionCheck, PackMigrationCheck, etc.)
+- `DerivedDoctorChecks.swift` — `deriveDoctorCheck()` extension on ComponentDefinition + SkillFreshnessCheck + ManifestFreshnessCheck
+- `ProjectDoctorChecks.swift` — project-scoped checks (CLAUDE.local.md version, Serena memory migration, state file)
+- `SectionValidator.swift` — validation of CLAUDE.local.md section markers
+- `MigrationDetector.swift` — detection of legacy bash installer artifacts
 
 ### Commands (`Sources/mcs/Commands/`)
 - `InstallCommand.swift` — 5-phase install flow with interactive selection
-- `DoctorCommand.swift` — health checks with optional --fix
-- `ConfigureCommand.swift` — project configuration with memory migration
-- `CleanupCommand.swift` — backup file management
+- `DoctorCommand.swift` — health checks with optional --fix and --pack filter
+- `ConfigureCommand.swift` — project configuration with --pack option and interactive flow
+- `CleanupCommand.swift` — backup file management with --force flag
+
+### Install (`Sources/mcs/Install/`)
+- `Installer.swift` — 5-phase orchestrator (welcome, selection, summary, install, post-summary)
+- `CoreComponents.swift` — all core component definitions, feature bundles, hook fragments
+- `SelectionState.swift` — tracks selected component IDs and branch prefix during install
+- `PackInstaller.swift` — auto-installs missing pack components during configure
+- `ProjectConfigurator.swift` — template composition, CLAUDE.local.md writing, Serena memory symlink, gitignore
 
 ### Templates (`Sources/mcs/Templates/`)
 - `TemplateEngine.swift` — `__PLACEHOLDER__` substitution
-- `TemplateComposer.swift` — section markers for composed files (`<!-- mcs:begin core v2.0.0 -->`)
+- `TemplateComposer.swift` — section markers for composed files (`<!-- mcs:begin core v2.0.0 -->`), section parsing, user content preservation
+
+### Core Pack (`Sources/mcs/Packs/Core/`)
+- `CoreTechPack.swift` — universal tech pack for any project, conditional template contributions (continuous learning, Serena)
+- `CoreTemplates.swift` — CLAUDE.local.md section templates for core features
 
 ### iOS Pack (`Sources/mcs/Packs/iOS/`)
-- `IOSTechPack.swift` — TechPack conformance
-- `IOSComponents.swift` — XcodeBuildMCP, Sosumi, xcodebuildmcp skill
-- `IOSDoctorChecks.swift` — Xcode CLT, pack-level supplementary checks
+- `IOSTechPack.swift` — TechPack conformance, Xcode project auto-detection
+- `IOSComponents.swift` — XcodeBuildMCP, Sosumi, xcodebuildmcp skill, gitignore entries
+- `IOSDoctorChecks.swift` — Xcode CLT check, XcodeBuildMCP config check, CLAUDE.local.md iOS section check
+- `IOSConstants.swift` — iOS-specific string constants
+- `IOSTemplates.swift` — iOS CLAUDE.local.md section template, XcodeBuildMCP config template
+- `IOSHookFragments.swift` — simulator status check fragment for session_start hook
 
 ### Resources (`Sources/mcs/Resources/`)
 Bundled with the binary via SwiftPM `.copy()`:
 - `config/settings.json` — Claude settings template
 - `hooks/` — session_start.sh, continuous-learning-activator.sh
 - `skills/continuous-learning/` — knowledge extraction skill
-- `commands/pr.md` — /pr slash command
+- `commands/pr.md, commit.md` — /pr and /commit slash commands
 - `templates/core/` — core CLAUDE.local.md template
 - `templates/packs/ios/` — iOS CLAUDE.local.md section, xcodebuildmcp.yaml
 
@@ -90,7 +116,10 @@ Bundled with the binary via SwiftPM `.copy()`:
 - **Section markers**: composed files use `<!-- mcs:begin/end -->` HTML comments to separate tool-managed content from user content
 - **File-based memory**: memories stored in `<project>/.claude/memories/*.md`, indexed by docs-mcp-server for semantic search
 - **Settings deep-merge**: native Swift Codable replaces jq; hooks deduplicate by command, plugins merge additively
+- **Settings ownership tracking**: sidecar file (`~/.claude/.mcs-settings-keys`) records which keys mcs manages, enabling stale key cleanup when the template changes
 - **Backup on every write**: timestamped backup created before any file modification
-- **Manifest tracking**: SHA-256 hashes + installed pack IDs in `~/.claude/.mcs-manifest` for doctor scoping and freshness checks
+- **Manifest tracking**: SHA-256 hashes + installed component IDs + installed pack IDs in `~/.claude/.mcs-manifest` for doctor scoping and freshness checks
 - **Component-derived doctor checks**: `ComponentDefinition` is the single source of truth — `deriveDoctorCheck()` auto-generates verification from `installAction`, supplementary checks handle extras; both install and doctor share the same detection logic
-- **Project awareness**: doctor detects project root (walk-up for `.git/`), resolves packs from `.claude/.mcs-project` before falling back to global manifest
+- **Project awareness**: doctor detects project root (walk-up for `.git/`), resolves packs from `.claude/.mcs-project` before falling back to section marker inference, then to global manifest
+- **Hook fragment injection**: pack hook contributions and core features (continuous learning) use versioned section markers (`# --- mcs:begin <id> v<version> ---`) for idempotent updates
+- **fix() responsibility boundary**: `doctor --fix` handles cleanup, migration, and trivial repairs only; additive operations (install/register/copy) are deferred to `mcs install` to keep the manifest as single source of truth

--- a/README.md
+++ b/README.md
@@ -1,172 +1,258 @@
-# My Claude Setup
+# mcs -- My Claude Setup
 
-One command to configure [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with MCP servers, plugins, skills, and hooks — technology-agnostic core with extensible tech packs.
-
-### What you get
-
-- 🧠 **Persistent memory** — learnings and decisions saved across sessions, searchable via semantic search
-- 🔍 **Automated PR reviews** — specialized agents for code quality, silent failures, and test coverage
-- ⚡ **Context-aware sessions** — every session starts with git state, branch protection, open PRs
-- 📋 **Per-project templates** — auto-generate `CLAUDE.local.md` tuned to your project
-- 🩺 **Self-healing setup** — built-in diagnostics that detect and auto-fix configuration drift
-- 📦 **Tech packs** — platform-specific tools loaded on demand (iOS pack included)
-
-> **Safe to try**: preview with `--dry-run`, pick only the components you need, automatic backups before any file changes. Fully idempotent — re-run anytime.
-
-## Quick Start
-
-### Via Homebrew (recommended)
+One command to turn Claude Code into a fully equipped development environment with persistent memory, automated workflows, and platform-specific tooling.
 
 ```bash
 brew install bguidolim/tap/my-claude-setup
 mcs install --all
 ```
 
-### One-line install
+That's it. Claude Code now has MCP servers for semantic search and documentation, plugins for PR reviews and iterative refinement, session hooks that load git context on startup, and a continuous learning system that remembers what it discovers across sessions.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/bguidolim/my-claude-setup/main/install.sh | bash
-```
+## What Problem Does This Solve?
+
+Claude Code is powerful out of the box, but getting the most from it requires configuring MCP servers, installing plugins, writing session hooks, managing settings, and maintaining per-project instruction files. Doing this manually is tedious, error-prone, and hard to keep consistent across machines and projects.
+
+`mcs` automates all of it. It installs and configures everything in one pass, tracks what it installed, detects configuration drift, and auto-fixes issues. It is non-destructive by design: every file write creates a timestamped backup, you can preview changes with `--dry-run`, and the interactive installer lets you pick only the components you want.
+
+## What You Get
+
+**Persistent Memory** -- Learnings and architectural decisions are extracted from sessions into markdown files, indexed by a local embedding model (Ollama + nomic-embed-text), and searchable via the docs-mcp-server MCP. Claude Code remembers what it learned last week.
+
+**Context-Aware Sessions** -- Every session starts with a hook that surfaces git status, branch protection rules, open PRs, and Ollama health. Claude Code knows where it is before you ask anything.
+
+**Automated PR Workflows** -- The `/pr` slash command stages, commits, pushes, and creates a pull request in one step, extracting ticket numbers from branch names. The `/commit` command does the same without the PR. Plugins add specialized review agents for code quality, silent failures, and test coverage.
+
+**Per-Project Configuration** -- `mcs configure` generates a `CLAUDE.local.md` file with instructions tuned to your project's technology stack, managed through section markers that separate tool-controlled content from your own notes.
+
+**Self-Healing Setup** -- `mcs doctor` runs a multi-layer diagnostic across dependencies, MCP servers, plugins, hooks, settings, file freshness, and project state. Add `--fix` to auto-repair what it can.
+
+**Tech Packs** -- Platform-specific tools are organized into installable packs. The iOS pack ships today with XcodeBuildMCP (build, test, run iOS/macOS apps), Sosumi (Apple documentation search), and simulator workflow guidance. The architecture supports additional packs for other platforms.
+
+## Quick Start
 
 ### Prerequisites
 
-- **macOS** (Apple Silicon or Intel)
-- **Anthropic account** with Claude Code access
-- **Xcode CLT** (for iOS pack): `xcode-select --install`
+- macOS (Apple Silicon or Intel)
+- Xcode Command Line Tools: `xcode-select --install`
+- Homebrew: [brew.sh](https://brew.sh)
+
+### Install via Homebrew
+
+```bash
+brew install bguidolim/tap/my-claude-setup
+```
+
+### Run the installer
+
+Install everything non-interactively:
+
+```bash
+mcs install --all
+```
+
+Or pick components interactively:
+
+```bash
+mcs install
+```
+
+### Configure your project
+
+```bash
+cd your-project
+mcs configure
+```
+
+This generates `CLAUDE.local.md` with instructions for your project, creates pack-specific configuration files (like `.xcodebuildmcp/config.yaml` for iOS projects), and sets up the memory directory.
+
+### Verify
+
+```bash
+mcs doctor
+```
 
 ## Usage
 
+### `mcs install`
+
+Installs and configures Claude Code components.
+
 ```bash
-mcs install                    # Interactive setup (pick components)
-mcs install --all              # Install everything
-mcs install --dry-run          # Preview what would be installed
-mcs install --pack ios         # Install iOS pack components
-mcs doctor                     # Diagnose installation health
-mcs doctor --fix               # Diagnose and auto-fix issues
-mcs configure-project [path]   # Generate CLAUDE.local.md for a project
-mcs cleanup                    # Find and delete backup files
-mcs update                     # Update via Homebrew
-mcs --help                     # Show usage
+mcs install                # Interactive -- pick components from a menu
+mcs install --all          # Install everything without prompts
+mcs install --dry-run      # Preview what would be installed (no changes)
+mcs install --pack ios     # Install only iOS tech pack components
+```
+
+The installer runs in five phases: system checks, component selection, dependency resolution, installation, and post-install summary. Dependencies like Node.js, Ollama, and the GitHub CLI are auto-resolved based on your selections.
+
+### `mcs doctor`
+
+Diagnoses installation health across seven layers of checks.
+
+```bash
+mcs doctor                 # Check core + installed packs
+mcs doctor --fix           # Check and auto-fix issues
+mcs doctor --pack ios      # Only check the iOS pack
+```
+
+When run inside a project, doctor automatically detects which packs are configured and scopes its checks accordingly. It reads from the project's `.mcs-project` state file, falls back to inferring packs from `CLAUDE.local.md` section markers, and finally consults the global manifest.
+
+### `mcs configure`
+
+Generates per-project `CLAUDE.local.md` and pack-specific files.
+
+```bash
+mcs configure              # Interactive pack selection
+mcs configure --pack ios   # Apply a specific pack
+mcs configure /path/to/project  # Target a different directory
+```
+
+Running configure on an already-configured project updates managed sections to the current version while preserving any content you added outside the section markers.
+
+### `mcs cleanup`
+
+Finds and deletes backup files created by previous installs and configurations.
+
+```bash
+mcs cleanup                # Interactive -- lists backups, asks before deleting
+mcs cleanup --force        # Delete without confirmation
 ```
 
 ## Components
 
-### Core (always available)
+### Core
 
 | Category | Component | Description |
 |----------|-----------|-------------|
-| MCP Server | **docs-mcp-server** | Semantic search over documentation and memories using local Ollama embeddings |
-| Plugin | **explanatory-output-style** | Enhanced output with educational insights |
-| Plugin | **pr-review-toolkit** | PR review agents (code quality, silent failures, test coverage) |
-| Plugin | **ralph-loop** | Iterative refinement loop for complex tasks |
-| Plugin | **claude-md-management** | Audit and improve CLAUDE.md files |
-| Skill | **continuous-learning** | Extracts learnings and decisions into memory files |
-| Command | **/pr** | Automates stage, commit, push, and PR creation with ticket extraction |
-| Hook | **session_start** | Git context, branch protection, open PRs, Ollama status, memory sync |
-| Hook | **continuous-learning-activator** | Reminds to evaluate learnings after each prompt |
-| Config | **settings.json** | Plan mode, always-thinking, env vars, hooks, plugins |
+| MCP Server | docs-mcp-server | Semantic search over project memories using local Ollama embeddings |
+| MCP Server | Serena | Semantic code navigation, symbol editing, and project context via LSP |
+| Plugin | explanatory-output-style | Enhanced output with educational insights |
+| Plugin | pr-review-toolkit | Specialized PR review agents for code quality, silent failures, test coverage |
+| Plugin | ralph-loop | Iterative refinement loop for complex multi-step tasks |
+| Plugin | claude-md-management | Audit and improve CLAUDE.md files |
+| Skill | continuous-learning | Extracts learnings and decisions from sessions into memory files |
+| Command | /pr | Stages, commits, pushes, and creates a PR with ticket extraction |
+| Command | /commit | Stages, commits, and pushes without PR creation |
+| Hook | session_start | Surfaces git status, branch protection, open PRs, Ollama health |
+| Hook | continuous-learning-activator | Reminds Claude to evaluate learnings after each prompt |
+| Config | settings.json | Plan mode, always-thinking, environment variables, hooks, plugins |
 
-### iOS Tech Pack (`--pack ios`)
+### iOS Tech Pack
+
+Installed with `mcs install --pack ios` or included in `mcs install --all`.
 
 | Category | Component | Description |
 |----------|-----------|-------------|
-| MCP Server | **XcodeBuildMCP** | Build, test, and run iOS/macOS apps via Xcode integration |
-| MCP Server | **Sosumi** | Search and fetch Apple Developer documentation |
-| Skill | **xcodebuildmcp** | Tool catalog and workflow guidance for 190+ iOS dev tools |
-| Template | **CLAUDE.local.md** | iOS-specific instructions (simulator, build & test rules) |
-| Config | **xcodebuildmcp.yaml** | Per-project XcodeBuildMCP workflow configuration |
+| MCP Server | XcodeBuildMCP | Build, test, and run iOS/macOS apps via Xcode integration |
+| MCP Server | Sosumi | Search and fetch Apple Developer documentation |
+| Skill | xcodebuildmcp | Tool catalog and workflow guidance for iOS development |
+| Template | CLAUDE.local.md section | iOS-specific instructions for simulator and build workflows |
+| Config | .xcodebuildmcp/config.yaml | Per-project XcodeBuildMCP configuration |
 
-### Dependencies (auto-resolved)
+### Auto-Resolved Dependencies
 
-Based on your selections, `mcs` automatically installs:
+Based on your selections, `mcs` automatically installs these if not already present:
 
-- **Homebrew** — if any packages need installing
-- **Node.js** — for npx-based MCP servers and skills
-- **gh** — GitHub CLI (when /pr command is selected)
-- **Ollama** + `nomic-embed-text` — for docs-mcp-server local embeddings
+- **Homebrew** -- macOS package manager
+- **Node.js** -- for npx-based MCP servers and skills
+- **GitHub CLI (gh)** -- for the /pr command
+- **jq** -- JSON processor used by session hooks
+- **Ollama** + nomic-embed-text -- local embeddings for docs-mcp-server
+- **uv** -- Python package runner for the Serena MCP server
+- **Claude Code** -- the Claude Code CLI itself
 
-## Memory Architecture
+## Memory System
 
-Memories are plain markdown files stored in `<project>/.claude/memories/`:
+The continuous learning system stores knowledge as plain markdown files in `<project>/.claude/memories/`:
 
 ```
-continuous-learning skill → Write tool → .claude/memories/*.md
-                                              ↓
-session_start hook → docs-mcp-server scrape → Ollama embeddings
-                                              ↓
-docs-mcp-server MCP → search_docs queries → semantic results
+Session work
+    |
+    v
+continuous-learning skill --> writes .claude/memories/*.md
+    |
+    v
+session_start hook --> docs-mcp-server scrape --> Ollama embeddings
+    |
+    v
+docs-mcp-server MCP --> search_docs --> semantic search results
 ```
 
-- **Learnings**: `learning_<topic>_<specific>.md` — non-obvious debugging, workarounds
-- **Decisions**: `decision_<domain>_<topic>.md` — architecture choices, conventions
+Memory files follow naming conventions:
 
-Memory files are gitignored and local to your machine.
+- `learning_<topic>_<detail>.md` -- non-obvious debugging insights, workarounds, gotchas
+- `decision_<domain>_<topic>.md` -- architecture choices, conventions, rationale
 
-## Per-Project Configuration
+These files are gitignored and local to your machine. If Serena is installed, `mcs configure` creates a `.serena/memories` symlink pointing to `.claude/memories` so both systems share the same knowledge base.
 
-After running `mcs install`, configure each project:
+## Safety Guarantees
 
-```bash
-cd your-project
-mcs configure-project
-```
-
-This generates:
-- `CLAUDE.local.md` with section markers for core + detected tech pack instructions
-- `.xcodebuildmcp/config.yaml` (for iOS projects)
-- Migrates memories from `.serena/memories/` if present
+- **Backup on every write**: timestamped backups created before any file modification (`settings.json.backup.20260222_143000`)
+- **Dry run**: `mcs install --dry-run` previews all changes without touching the filesystem
+- **Interactive selection**: pick only the components you need, or use `--all` for everything
+- **Idempotent**: re-run `mcs install` any time -- already-installed components are detected and skipped
+- **Non-destructive settings merge**: existing `settings.json` entries are preserved; only new keys are added
+- **Section markers**: `CLAUDE.local.md` uses HTML comment markers (`<!-- mcs:begin/end -->`) to separate managed content from your own
+- **Manifest tracking**: SHA-256 hashes of installed files detect configuration drift
 
 ## Tech Pack System
 
 Components are organized into tech packs. The core is technology-agnostic; platform-specific tools live in packs.
 
 Currently shipped:
-- **Core** — memory, PR workflows, session hooks, plugins
-- **iOS** — XcodeBuildMCP, Sosumi, simulator management
+- **Core** -- memory, PR workflows, session hooks, plugins, Serena
+- **iOS** -- XcodeBuildMCP, Sosumi, simulator management, Xcode integration
 
-Future packs (contributions welcome):
-- Android, Web, Backend, etc.
-
-Tech packs are compiled into a single binary — no separate installation needed.
+Packs are compiled into the single `mcs` binary -- no separate downloads or plugin registries. See [docs/creating-tech-packs.md](docs/creating-tech-packs.md) for how to create new packs.
 
 ## Troubleshooting
 
-### Ollama not starting
+Run `mcs doctor` to diagnose issues. Common problems:
+
+**Ollama not running**
 ```bash
-curl http://localhost:11434/api/tags   # Check status
-brew services start ollama             # Start via Homebrew
+ollama serve                       # Start in foreground
+brew services start ollama         # Or start as background service
+ollama pull nomic-embed-text       # Ensure embedding model is installed
 ```
 
-### MCP servers not appearing
+**MCP servers not appearing in Claude Code**
 ```bash
-claude mcp list                        # List configured servers
-mcs doctor --fix                       # Auto-fix registration
+claude mcp list                    # List registered servers
+mcs doctor --fix                   # Auto-fix what can be fixed
+mcs install                        # Re-run install for additive repairs
 ```
 
-### Migration from Bash version
+**CLAUDE.local.md out of date**
 ```bash
-brew install bguidolim/tap/my-claude-setup
-mcs install --all
-mcs configure-project                  # In each project
-mcs doctor                             # Verify everything
-rm -rf ~/.claude-ios-setup ~/.claude/bin/claude-ios-setup  # Cleanup old install
+mcs configure                      # Regenerate with current templates
 ```
 
-## Backups
-
-All file writes create timestamped backups:
-- `~/.claude/settings.json.backup.YYYYMMDD_HHMMSS`
-- `<project>/CLAUDE.local.md.backup.YYYYMMDD_HHMMSS`
-
-Use `mcs cleanup` to find and delete old backups.
+See [docs/troubleshooting.md](docs/troubleshooting.md) for a complete guide.
 
 ## Development
 
 ```bash
-swift build                            # Build
-swift test                             # Run tests (50 tests)
-swift build -c release --arch arm64 --arch x86_64  # Universal binary
+swift build                                              # Build debug
+swift test                                               # Run tests
+swift build -c release --arch arm64 --arch x86_64        # Universal release binary
 ```
+
+See [docs/architecture.md](docs/architecture.md) for the project structure and design decisions.
+
+## Contributing
+
+Contributions are welcome, especially new tech packs. See [docs/creating-tech-packs.md](docs/creating-tech-packs.md) for a step-by-step guide to building a tech pack.
+
+To contribute:
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Run `swift test` to verify
+5. Open a pull request
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,243 @@
+# Architecture
+
+This document describes the internal architecture of `mcs` for contributors and anyone extending the codebase.
+
+## Package Structure
+
+```
+Package.swift                    # swift-tools-version: 6.0, macOS 13+
+Sources/mcs/
+    CLI.swift                    # @main entry, version, subcommand registration
+    Core/                        # Shared infrastructure
+    Commands/                    # CLI subcommands (install, doctor, configure, cleanup)
+    Install/                     # Installation logic, component definitions, project configuration
+    TechPack/                    # Tech pack protocol, component model, dependency resolver
+    Templates/                   # Template engine and section-based file composition
+    Doctor/                      # Diagnostic checks and fix logic
+    Packs/
+        Core/                    # Universal tech pack (works with any project)
+        iOS/                     # iOS/macOS development tech pack
+    Resources/                   # Bundled config, hooks, skills, commands, templates
+Tests/MCSTests/                  # Test target
+```
+
+## Core Infrastructure
+
+### Environment (`Core/Environment.swift`)
+
+Central path resolution for all file locations. Detects architecture (arm64/x86_64), resolves Homebrew path, and locates the user's shell RC file. Key paths:
+
+- `~/.claude/` -- Claude Code configuration directory
+- `~/.claude/settings.json` -- user settings
+- `~/.claude.json` -- MCP server registrations
+- `~/.claude/hooks/` -- session hooks
+- `~/.claude/skills/` -- installed skills
+- `~/.claude/commands/` -- slash commands
+- `~/.claude/.mcs-manifest` -- manifest tracking installed files
+- `~/.claude/.mcs-settings-keys` -- settings ownership sidecar
+
+### Settings (`Core/Settings.swift`, `Core/SettingsOwnership.swift`)
+
+`Settings` is a Codable model that mirrors the structure of `~/.claude/settings.json`. It supports deep-merge: when merging a template into existing settings, hooks are deduplicated by command string, plugins are merged additively, and scalar values from the template take precedence.
+
+`SettingsOwnership` tracks which top-level keys in `settings.json` were written by mcs. This enables stale key cleanup: when a key is removed from the template in a new version, `mcs install` detects and removes it from the user's settings without disturbing user-added keys.
+
+### Manifest (`Core/Manifest.swift`)
+
+Tracks what mcs has installed using three data structures:
+
+1. **File hashes**: SHA-256 hashes of bundled resources at install time, enabling freshness checks
+2. **Installed component IDs**: set of component identifiers (e.g., `core.docs-mcp-server`, `ios.xcodebuildmcp`)
+3. **Installed pack IDs**: set of pack identifiers (e.g., `ios`)
+
+The manifest is the system's source of truth for "what is installed." Doctor checks read it to determine scope; the installer writes to it after each successful component installation.
+
+### Backup (`Core/Backup.swift`)
+
+Every file write goes through the backup system. Before overwriting a file, a timestamped copy is created (e.g., `settings.json.backup.20260222_143000`). The `mcs cleanup` command discovers and deletes these backups.
+
+### HookInjector (`Core/HookInjector.swift`)
+
+Injects script fragments into hook files using versioned section markers:
+
+```bash
+# --- mcs:begin ios v2.0.0 ---
+# ... injected fragment ...
+# --- mcs:end ios ---
+```
+
+This pattern enables idempotent updates: running install again replaces the fragment between markers without affecting the rest of the hook file. Both tech pack hook contributions and core features (continuous learning) use this mechanism.
+
+## Install Flow
+
+The installer (`Install/Installer.swift`) runs five phases:
+
+### Phase 1: Welcome
+System checks (macOS, not root, Xcode CLT, Homebrew). Manifest migration from legacy formats.
+
+### Phase 2: Selection
+Three modes:
+- `--all`: selects every component from core and all packs
+- `--pack <name>`: selects all components from the named pack
+- Interactive: presents grouped multi-select menu with feature bundles
+
+Feature bundles (`CoreComponents.bundles`) group related components into a single selectable item. For example, "Continuous Learning" bundles `docs-mcp-server` + `continuous-learning` skill + `continuous-learning-activator` hook.
+
+### Phase 3: Summary
+Shows the dependency-resolved installation plan grouped by type. Auto-resolved dependencies are annotated. In `--dry-run` mode, stops here.
+
+### Phase 4: Install
+Iterates through the resolved plan in topological order. For each component:
+1. Checks if already installed using the same doctor check logic (shared detection)
+2. Executes the component's install action
+3. Records the component in the manifest
+4. Runs post-install steps (e.g., starting Ollama, pulling models)
+
+After all components: injects hook contributions, adds gitignore entries, registers continuous learning hooks.
+
+### Phase 5: Post-Summary
+Shows installed/skipped items. Offers inline project configuration for interactive installs.
+
+## Dependency Resolution
+
+`DependencyResolver` performs a topological sort of selected components plus their transitive dependencies. It detects cycles and auto-adds dependencies that weren't explicitly selected (marking them as "(auto-resolved)" in the summary).
+
+Components declare dependencies by ID:
+
+```swift
+static let docsMCPServer = ComponentDefinition(
+    id: "core.docs-mcp-server",
+    dependencies: ["core.node", "core.ollama"],
+    // ...
+)
+```
+
+## Component Model
+
+Each installable unit is a `ComponentDefinition` with:
+
+- **id**: unique identifier (e.g., `ios.xcodebuildmcp`)
+- **type**: `mcpServer`, `plugin`, `skill`, `hookFile`, `command`, `brewPackage`, `configuration`
+- **packIdentifier**: `nil` for core, pack ID for pack components
+- **dependencies**: IDs of components this depends on
+- **isRequired**: if true, always installed with its pack
+- **installAction**: how to install (see below)
+- **supplementaryChecks**: doctor checks that can't be auto-derived
+
+### Install Actions
+
+```swift
+enum ComponentInstallAction {
+    case mcpServer(MCPServerConfig)     // Register via `claude mcp add`
+    case plugin(name: String)            // Install via `claude plugin install`
+    case copySkill(source, destination)  // Copy bundled skill directory
+    case copyHook(source, destination)   // Copy bundled hook script
+    case copyCommand(source, dest, placeholders)  // Copy with placeholder substitution
+    case brewInstall(package: String)    // Install via Homebrew
+    case shellCommand(command: String)   // Run arbitrary shell command
+    case settingsMerge                   // Deep-merge settings template
+    case gitignoreEntries(entries)       // Add to global gitignore
+}
+```
+
+## Tech Pack Protocol
+
+```swift
+protocol TechPack: Sendable {
+    var identifier: String { get }
+    var displayName: String { get }
+    var description: String { get }
+    var components: [ComponentDefinition] { get }
+    var templates: [TemplateContribution] { get }
+    var hookContributions: [HookContribution] { get }
+    var gitignoreEntries: [String] { get }
+    var supplementaryDoctorChecks: [any DoctorCheck] { get }
+    var migrations: [any PackMigration] { get }
+    func configureProject(at path: URL, context: ProjectConfigContext) throws
+}
+```
+
+Packs provide:
+- **Components**: installable units (MCP servers, skills, etc.)
+- **Templates**: sections to inject into `CLAUDE.local.md`
+- **Hook contributions**: script fragments to inject into existing hooks
+- **Gitignore entries**: patterns to add to the global gitignore
+- **Supplementary doctor checks**: pack-level diagnostics not derivable from components
+- **Migrations**: versioned data migrations run by `doctor --fix`
+- **Project configuration**: pack-specific setup (e.g., iOS generates `.xcodebuildmcp/config.yaml`)
+
+The registry (`TechPackRegistry`) holds all compiled-in packs and provides filtering by installed state.
+
+## Doctor System
+
+`DoctorRunner` orchestrates checks across seven layers:
+
+1. **Derived checks**: auto-generated from each component's `installAction` via `deriveDoctorCheck()`
+2. **Supplementary component checks**: additional checks declared on components
+3. **Supplementary pack checks**: pack-level concerns not tied to a specific component
+4. **Standalone checks**: cross-component concerns (hook event registration, settings validation, gitignore, manifest freshness)
+5. **Deprecation checks**: detect and optionally remove legacy components
+6. **Hook contribution checks**: verify pack hook fragments are injected and up to date
+7. **Project checks**: CLAUDE.local.md version, Serena memory migration, project state file
+
+### fix() Responsibility Boundary
+
+`doctor --fix` only handles:
+- **Cleanup**: removing deprecated components
+- **Migration**: one-time data moves (memories, state files)
+- **Trivial repairs**: permission fixes, gitignore additions
+
+`doctor --fix` does NOT handle additive operations (installing packages, registering servers, copying files). These are `mcs install`'s responsibility because only install manages the manifest. This prevents inconsistent state where a file exists but the manifest doesn't track it.
+
+### Pack Resolution
+
+When determining which packs to check, doctor uses a priority chain:
+1. Explicit `--pack` flag
+2. Project `.mcs-project` state file
+3. Inferred from `CLAUDE.local.md` section markers
+4. Global manifest
+
+## Template System
+
+### TemplateEngine
+
+Simple `__PLACEHOLDER__` substitution. Values are passed as `[String: String]` dictionaries.
+
+### TemplateComposer
+
+Manages section markers in `CLAUDE.local.md`:
+
+```html
+<!-- mcs:begin core v2.0.0 -->
+... managed content ...
+<!-- mcs:end core -->
+
+<!-- mcs:begin ios v2.0.0 -->
+... managed content ...
+<!-- mcs:end ios -->
+
+(user content preserved outside markers)
+```
+
+Key operations:
+- `compose()`: create a new file from contributions
+- `replaceSection()`: update a section in an existing file
+- `extractUserContent()`: preserve content outside markers during updates
+- `parseSections()`: extract section identifiers and versions
+
+## Project Configuration
+
+`ProjectConfigurator` handles per-project setup:
+
+1. Auto-installs missing pack components via `PackInstaller`
+2. Resolves the repository name from git
+3. Gathers template contributions from CoreTechPack and the selected pack
+4. Writes/updates `CLAUDE.local.md` preserving user content
+5. Creates `.serena/memories` symlink to `.claude/memories` (if Serena is installed)
+6. Ensures global gitignore entries
+7. Runs pack-specific configuration (e.g., iOS creates `.xcodebuildmcp/config.yaml`)
+8. Writes `.claude/.mcs-project` state file
+
+## Concurrency Model
+
+The codebase uses Swift 6's strict concurrency. All core types conform to `Sendable`. `TechPack` is a `Sendable` protocol. The registry is a static `let` singleton. No mutable global state exists outside the installer's in-progress mutation context.

--- a/docs/creating-tech-packs.md
+++ b/docs/creating-tech-packs.md
@@ -1,0 +1,300 @@
+# Creating Tech Packs
+
+This guide walks through creating a new tech pack for `mcs`. Tech packs add platform-specific MCP servers, templates, hooks, doctor checks, and project configuration to the core setup.
+
+## Overview
+
+A tech pack is a Swift type conforming to the `TechPack` protocol. Packs are compiled into the `mcs` binary -- there is no plugin system or runtime discovery. To add a pack, you add Swift files to the repository, register the pack in the registry, and rebuild.
+
+## Step 1: Create the Pack Directory
+
+Create a new directory under `Sources/mcs/Packs/`:
+
+```
+Sources/mcs/Packs/YourPack/
+    YourPackTechPack.swift       # TechPack conformance
+    YourPackComponents.swift     # Component definitions
+    YourPackDoctorChecks.swift   # Supplementary doctor checks
+    YourPackConstants.swift      # String constants
+    YourPackTemplates.swift      # CLAUDE.local.md section template
+    YourPackHookFragments.swift  # Hook script fragments (optional)
+```
+
+## Step 2: Define Components
+
+Components are the installable units of your pack. Each component has an install action and metadata.
+
+```swift
+import Foundation
+
+enum YourPackComponents {
+    static let someMCPServer = ComponentDefinition(
+        id: "yourpack.some-server",            // Unique ID: "<pack>.<name>"
+        displayName: "Some MCP Server",
+        description: "What it does",
+        type: .mcpServer,
+        packIdentifier: "yourpack",            // Must match pack identifier
+        dependencies: ["core.node"],           // IDs of required components
+        isRequired: false,                     // true = always installed with pack
+        installAction: .mcpServer(MCPServerConfig(
+            name: "some-server",
+            command: "npx",
+            args: ["-y", "some-server@latest"],
+            env: [:]
+        ))
+    )
+
+    static let someSkill = ComponentDefinition(
+        id: "yourpack.skill.something",
+        displayName: "Something skill",
+        description: "Skill description",
+        type: .skill,
+        packIdentifier: "yourpack",
+        dependencies: ["yourpack.some-server"],
+        isRequired: false,
+        installAction: .shellCommand(
+            command: "npx -y skills add some-org/some-skill -g -a claude-code -y"
+        ),
+        supplementaryChecks: [SomeSkillCheck()]  // Custom doctor check
+    )
+
+    static let gitignore = ComponentDefinition(
+        id: "yourpack.gitignore",
+        displayName: "YourPack gitignore entries",
+        description: "Add .yourpack to global gitignore",
+        type: .configuration,
+        packIdentifier: "yourpack",
+        dependencies: [],
+        isRequired: true,
+        installAction: .gitignoreEntries(entries: [".yourpack"])
+    )
+
+    static let all: [ComponentDefinition] = [
+        someMCPServer,
+        someSkill,
+        gitignore,
+    ]
+}
+```
+
+### Install Action Types
+
+| Action | Use Case |
+|--------|----------|
+| `.mcpServer(MCPServerConfig)` | Register an MCP server via `claude mcp add` |
+| `.mcpServer(.http(name:url:))` | Register an HTTP transport MCP server |
+| `.plugin(name:)` | Install a Claude Code plugin |
+| `.copySkill(source:destination:)` | Copy a bundled skill directory from Resources |
+| `.copyHook(source:destination:)` | Copy a bundled hook script from Resources |
+| `.copyCommand(source:destination:placeholders:)` | Copy a command file with placeholder substitution |
+| `.brewInstall(package:)` | Install a Homebrew package |
+| `.shellCommand(command:)` | Run an arbitrary shell command |
+| `.gitignoreEntries(entries:)` | Add patterns to the global gitignore |
+
+### Dependency IDs
+
+Core components you can depend on:
+- `core.homebrew` -- Homebrew package manager
+- `core.node` -- Node.js (for npx-based tools)
+- `core.gh` -- GitHub CLI
+- `core.jq` -- JSON processor
+- `core.ollama` -- Ollama LLM runtime
+- `core.uv` -- Python package runner
+
+## Step 3: Create the Template
+
+Templates contribute sections to `CLAUDE.local.md`. Define your template content:
+
+```swift
+enum YourPackTemplates {
+    static let claudeLocalSection = """
+    ## YourPack-Specific Instructions
+
+    When working on this project, follow these guidelines:
+
+    - Guideline 1
+    - Guideline 2
+
+    Project: __PROJECT__
+    """
+}
+```
+
+Placeholders use the `__NAME__` format and are substituted by the template engine during `mcs configure`. Common placeholders:
+- `__PROJECT__` -- project directory name
+- `__REPO_NAME__` -- git repository name
+
+## Step 4: Add Hook Contributions (Optional)
+
+If your pack needs to inject script fragments into existing hooks:
+
+```swift
+enum YourPackHookFragments {
+    static let statusCheck = """
+        # === YOUR PACK STATUS CHECK ===
+        if some_command_exists; then
+            context+="\\nYourPack: ready"
+        fi
+    """
+}
+```
+
+Hook contributions are injected using section markers, making them idempotent and version-tracked.
+
+## Step 5: Implement Supplementary Doctor Checks
+
+Doctor checks that cannot be auto-derived from component install actions go here. Auto-derived checks handle the common cases:
+- `.mcpServer` -> checks registration in `~/.claude.json`
+- `.plugin` -> checks enablement in `settings.json`
+- `.brewInstall` -> checks command availability
+- `.copyHook` -> checks file existence and executability
+- `.copySkill` -> checks directory existence
+- `.copyCommand` -> checks file existence
+
+Supplementary checks cover everything else:
+
+```swift
+struct YourToolCheck: DoctorCheck, Sendable {
+    let section = "YourPack"          // Grouping header in doctor output
+    let name = "your tool name"
+
+    func check() -> CheckResult {
+        // Return .pass, .fail, .warn, or .skip
+        if toolIsConfigured() {
+            return .pass("configured correctly")
+        }
+        return .fail("not configured -- run 'mcs configure --pack yourpack'")
+    }
+
+    func fix() -> FixResult {
+        // Return .fixed, .failed, or .notFixable
+        // Remember: doctor --fix only does cleanup/migration/trivial repairs
+        // Additive operations should return .notFixable with install guidance
+        return .notFixable("Run 'mcs install' to configure")
+    }
+}
+```
+
+## Step 6: Implement the TechPack Protocol
+
+```swift
+import Foundation
+
+struct YourPackTechPack: TechPack {
+    let identifier = "yourpack"
+    let displayName = "Your Pack"
+    let description = "Description of what this pack provides"
+
+    let components: [ComponentDefinition] = YourPackComponents.all
+
+    let templates: [TemplateContribution] = [
+        TemplateContribution(
+            sectionIdentifier: "yourpack",
+            templateContent: YourPackTemplates.claudeLocalSection,
+            placeholders: ["__PROJECT__"]
+        ),
+    ]
+
+    let hookContributions: [HookContribution] = [
+        HookContribution(
+            hookName: "session_start",
+            scriptFragment: YourPackHookFragments.statusCheck,
+            position: .after          // .before or .after core content
+        ),
+    ]
+
+    let gitignoreEntries: [String] = [".yourpack"]
+
+    var supplementaryDoctorChecks: [any DoctorCheck] {
+        [YourToolCheck()]
+    }
+
+    func configureProject(at path: URL, context: ProjectConfigContext) throws {
+        // Create pack-specific project files
+        let configDir = path.appendingPathComponent(".yourpack")
+        let configFile = configDir.appendingPathComponent("config.yaml")
+
+        let content = "project: \(context.repoName)\n"
+
+        try FileManager.default.createDirectory(
+            at: configDir,
+            withIntermediateDirectories: true
+        )
+        try content.write(to: configFile, atomically: true, encoding: .utf8)
+    }
+}
+```
+
+## Step 7: Register the Pack
+
+Add your pack to the registry in `Sources/mcs/TechPack/TechPackRegistry.swift`:
+
+```swift
+struct TechPackRegistry: Sendable {
+    static let shared = TechPackRegistry(packs: [
+        CoreTechPack(),
+        IOSTechPack(),
+        YourPackTechPack(),  // Add here
+    ])
+    // ...
+}
+```
+
+## Step 8: Add Bundled Resources (If Needed)
+
+If your pack includes bundled files (templates, configs), add them to `Sources/mcs/Resources/templates/packs/yourpack/`.
+
+Resources are included in the binary via the `.copy("Resources")` directive in `Package.swift`.
+
+## Step 9: Add Tests
+
+Create tests in `Tests/MCSTests/` that verify:
+- Component definitions have valid IDs and dependencies
+- Doctor checks return expected results
+- Templates contain required placeholders
+- `configureProject` creates expected files
+
+## Step 10: Build and Verify
+
+```bash
+swift build                          # Verify compilation
+swift test                           # Run tests
+mcs install --pack yourpack          # Test installation
+mcs doctor --pack yourpack           # Test diagnostics
+mcs configure --pack yourpack        # Test project configuration
+```
+
+## Design Guidelines
+
+### Component IDs
+Use the format `<pack>.<name>` or `<pack>.<type>.<name>`:
+- `yourpack.some-server`
+- `yourpack.skill.something`
+
+### Doctor Check Sections
+Use your pack name as the section header for supplementary checks. Auto-derived checks use the component type (MCP Servers, Plugins, etc.).
+
+### fix() Boundaries
+Doctor `--fix` should only handle:
+- Cleanup of deprecated items
+- One-time data migrations
+- Permission fixes
+
+Additive operations (installing, registering, copying) should return `.notFixable("Run 'mcs install' to ...")`.
+
+### Sendable Conformance
+All types must conform to `Sendable` (Swift 6 strict concurrency). Use `struct` for checks and pack types. Avoid mutable shared state.
+
+### Idempotency
+Install actions should be safe to re-run. The installer checks `isAlreadyInstalled()` using auto-derived and supplementary doctor checks before executing install actions. Components that pass any check are skipped.
+
+## Reference: iOS Pack
+
+The iOS tech pack (`Sources/mcs/Packs/iOS/`) is the reference implementation:
+
+- `IOSTechPack.swift` -- protocol conformance, Xcode project auto-detection
+- `IOSComponents.swift` -- XcodeBuildMCP, Sosumi, skill, gitignore
+- `IOSDoctorChecks.swift` -- Xcode CLT, config.yaml, CLAUDE.local.md section
+- `IOSConstants.swift` -- string constants
+- `IOSTemplates.swift` -- CLAUDE.local.md section, XcodeBuildMCP config
+- `IOSHookFragments.swift` -- simulator check for session_start hook

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,336 @@
+# Troubleshooting
+
+This guide covers common issues and how to resolve them. Start by running `mcs doctor` to get a diagnostic report -- most problems will show up there.
+
+```bash
+mcs doctor           # Diagnose
+mcs doctor --fix     # Diagnose and auto-fix what's possible
+```
+
+## Dependencies
+
+### Homebrew not installed
+
+**Symptom**: `mcs install` fails at the welcome phase with "Homebrew is required but not installed."
+
+**Fix**: Install Homebrew first:
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Then re-run `mcs install`.
+
+### Xcode Command Line Tools missing
+
+**Symptom**: `mcs install` fails with "Xcode Command Line Tools not found."
+
+**Fix**:
+```bash
+xcode-select --install
+```
+
+Follow the system dialog to complete installation, then re-run `mcs install`.
+
+### Node.js not found
+
+**Symptom**: MCP servers that use `npx` fail to start or install.
+
+**Fix**: Node.js is auto-resolved as a dependency. Re-run:
+```bash
+mcs install
+```
+
+If you manage Node.js through nvm or similar, make sure it's available in your PATH during installation.
+
+### Ollama not running
+
+**Symptom**: `mcs doctor` shows "Ollama: not running" or semantic search fails.
+
+**Fix**: Start Ollama:
+```bash
+ollama serve                      # Foreground (for debugging)
+brew services start ollama        # Background service
+```
+
+If the embedding model is missing:
+```bash
+ollama pull nomic-embed-text
+```
+
+Verify it's working:
+```bash
+curl http://localhost:11434/api/tags
+```
+
+### Claude Code CLI not found
+
+**Symptom**: MCP servers and plugins can't be registered.
+
+**Fix**: Install Claude Code:
+```bash
+brew install --cask claude-code
+```
+
+Verify:
+```bash
+claude --version
+```
+
+## MCP Servers
+
+### MCP server not registered
+
+**Symptom**: `mcs doctor` shows a server as "not registered" or `claude mcp list` doesn't show it.
+
+**Fix**: Re-run the installer:
+```bash
+mcs install
+```
+
+The installer checks for existing registrations and only adds what's missing.
+
+### docs-mcp-server semantic search not working
+
+**Symptom**: `search_docs` returns no results or errors.
+
+**Causes**:
+1. Ollama is not running
+2. The `nomic-embed-text` model is not pulled
+3. The project library has not been indexed
+
+**Fix**:
+```bash
+# 1. Start Ollama
+ollama serve
+
+# 2. Pull the embedding model
+ollama pull nomic-embed-text
+
+# 3. Verify the library exists
+OPENAI_API_KEY=ollama OPENAI_API_BASE=http://localhost:11434/v1 \
+  npx -y @arabold/docs-mcp-server list
+
+# 4. If missing, manually scrape
+OPENAI_API_KEY=ollama OPENAI_API_BASE=http://localhost:11434/v1 \
+  npx -y @arabold/docs-mcp-server scrape "your-repo-name" \
+  "file://$(pwd)/.claude/memories" \
+  --embedding-model "openai:nomic-embed-text"
+```
+
+The session_start hook normally handles indexing automatically when Ollama is running.
+
+### Sosumi not responding
+
+**Symptom**: Apple documentation search via Sosumi returns errors.
+
+Sosumi uses HTTP transport (external service at `https://sosumi.ai/mcp`). Check your internet connection and verify the server is registered:
+```bash
+claude mcp list
+```
+
+If not registered, re-run `mcs install --pack ios`.
+
+## Plugins
+
+### Plugin not enabled
+
+**Symptom**: `mcs doctor` shows a plugin as "not enabled."
+
+**Fix**: Re-run installation:
+```bash
+mcs install
+```
+
+You can also manually install a plugin:
+```bash
+claude plugin install <plugin-name>@claude-plugins-official
+```
+
+## Hooks
+
+### Hook not executable
+
+**Symptom**: `mcs doctor` shows "not executable" for a hook file.
+
+**Fix**: `mcs doctor --fix` can repair this automatically. Or manually:
+```bash
+chmod +x ~/.claude/hooks/session_start.sh
+chmod +x ~/.claude/hooks/continuous-learning-activator.sh
+```
+
+### Legacy hook missing extension marker
+
+**Symptom**: `mcs doctor` shows "legacy hook -- missing extension marker, needs update."
+
+This means the hook file was installed by an older version that didn't support fragment injection.
+
+**Fix**: Re-run installation to replace the hook:
+```bash
+mcs install
+```
+
+### Hook fragment version mismatch
+
+**Symptom**: `mcs doctor` shows something like "v1.0.0 installed, v2.0.0 available."
+
+**Fix**: Re-run installation to update:
+```bash
+mcs install
+```
+
+## Settings
+
+### defaultMode not set to 'plan'
+
+**Symptom**: `mcs doctor` warns about settings configuration.
+
+**Fix**: Re-run installation to merge settings:
+```bash
+mcs install
+```
+
+Settings are deep-merged: existing user settings are preserved, and template values are added.
+
+### Stale settings keys
+
+**Symptom**: `mcs doctor` warns about stale settings keys.
+
+This means a previous version of mcs added settings keys that the current version no longer manages.
+
+**Fix**: Re-run installation:
+```bash
+mcs install
+```
+
+The installer detects and removes stale keys automatically.
+
+## Project Configuration
+
+### CLAUDE.local.md not found
+
+**Symptom**: `mcs doctor` skips project checks or shows "CLAUDE.local.md not found."
+
+**Fix**: Configure the project:
+```bash
+cd /path/to/your/project
+mcs configure
+```
+
+### CLAUDE.local.md sections outdated
+
+**Symptom**: `mcs doctor` shows "outdated sections" with version mismatches.
+
+**Fix**: Re-run configure to update sections:
+```bash
+cd /path/to/your/project
+mcs configure
+```
+
+Managed sections (inside `<!-- mcs:begin/end -->` markers) are updated. Content you added outside markers is preserved.
+
+### .mcs-project file missing
+
+**Symptom**: `mcs doctor` warns "CLAUDE.local.md exists but .mcs-project missing."
+
+**Fix**: `mcs doctor --fix` can create the state file by inferring packs from CLAUDE.local.md section markers. Or re-run configure:
+```bash
+mcs configure
+```
+
+### XcodeBuildMCP config.yaml missing (iOS)
+
+**Symptom**: `mcs doctor` shows ".xcodebuildmcp/config.yaml: Missing."
+
+**Fix**:
+```bash
+cd /path/to/your/ios/project
+mcs configure --pack ios
+```
+
+### XcodeBuildMCP config.yaml has placeholder
+
+**Symptom**: `mcs doctor` warns "Present but __PROJECT__ placeholder not filled in."
+
+This means `mcs configure` could not auto-detect an `.xcworkspace` or `.xcodeproj` file in the project directory.
+
+**Fix**: Manually edit `.xcodebuildmcp/config.yaml` and replace `__PROJECT__` with your actual Xcode project or workspace file name.
+
+## Serena Memory Migration
+
+### .serena/memories exists as directory
+
+**Symptom**: `mcs doctor` shows ".serena/memories/ has N file(s) -- migrate to .claude/memories/."
+
+If you previously used Serena with a separate memories directory, it should be migrated to `.claude/memories/` and replaced with a symlink.
+
+**Fix**: `mcs doctor --fix` handles this automatically:
+```bash
+cd /path/to/your/project
+mcs doctor --fix
+```
+
+This copies files from `.serena/memories/` to `.claude/memories/`, removes the original directory, and creates a symlink.
+
+## Migration from Legacy Versions
+
+### Deprecated MCP servers or plugins
+
+**Symptom**: `mcs doctor` warns about deprecated components like `mcp-omnisearch` or `claude-hud`.
+
+**Fix**: `mcs doctor --fix` removes deprecated components automatically:
+```bash
+mcs doctor --fix
+```
+
+### Migrating from the bash installer
+
+If you previously used the bash-based installer (`claude-ios-setup`):
+
+```bash
+# 1. Install the new version
+brew install bguidolim/tap/my-claude-setup
+
+# 2. Run full install (handles manifest migration)
+mcs install --all
+
+# 3. Configure each project
+cd /path/to/project && mcs configure
+
+# 4. Verify
+mcs doctor
+
+# 5. Clean up old installation
+rm -rf ~/.claude-ios-setup ~/.claude/bin/claude-ios-setup
+```
+
+## Global Gitignore
+
+### Missing gitignore entries
+
+**Symptom**: `mcs doctor` shows "missing entries" in the gitignore check.
+
+**Fix**: `mcs doctor --fix` adds missing entries automatically:
+```bash
+mcs doctor --fix
+```
+
+## Backup Files
+
+### Too many backup files
+
+Over time, `mcs install` and `mcs configure` create timestamped backups of files they modify.
+
+**Fix**: Clean them up:
+```bash
+mcs cleanup          # Lists backups and asks before deleting
+mcs cleanup --force  # Deletes without confirmation
+```
+
+## Getting More Help
+
+If `mcs doctor` doesn't identify the problem:
+
+1. Check that your PATH includes the necessary binaries (`brew`, `node`, `claude`, `ollama`)
+2. Verify `~/.claude.json` is valid JSON: `python3 -m json.tool ~/.claude.json`
+3. Verify `~/.claude/settings.json` is valid JSON: `python3 -m json.tool ~/.claude/settings.json`
+4. Open an issue at the project repository with the output of `mcs doctor`


### PR DESCRIPTION
## Summary
- Rewrites README with problem-focused introduction, clearer component tables, safety guarantees section, and links to new docs
- Updates CLAUDE.md with 15+ missing file entries, 3 new design decisions, and corrected descriptions
- Adds `docs/` folder: architecture overview, tech pack creation guide, and troubleshooting reference

## Changes
- **README.md** — complete rewrite (+186/-100 lines): focuses on "what problem does this solve", adds safety guarantees section, proper dependency table, contributing section, doc links
- **CLAUDE.md** — expanded architecture map: added Install/, Core Pack, Entry Point sections; added `SettingsOwnership`, `HookInjector`, `OllamaService`, `MCSError`, `SectionValidator`, `MigrationDetector`, `IOSConstants`, `IOSTemplates`, `IOSHookFragments`; 3 new design decisions (settings ownership tracking, hook fragment injection, fix() responsibility boundary)
- **docs/architecture.md** (new, ~243 lines) — internal architecture reference for contributors
- **docs/creating-tech-packs.md** (new, ~300 lines) — step-by-step guide to building a tech pack
- **docs/troubleshooting.md** (new, ~336 lines) — common issues and fixes organized by category

## Test plan
- [x] Verify all internal links in README resolve correctly
- [x] Verify code examples in docs match current CLI interface
- [x] Confirm CLAUDE.md file list matches actual source tree