### PR TITLE
Fix HookCheck false error on standalone hooks

### DIFF
--- a/Sources/mcs/Doctor/CoreDoctorChecks.swift
+++ b/Sources/mcs/Doctor/CoreDoctorChecks.swift
@@ -148,9 +148,6 @@ struct HookCheck: DoctorCheck, Sendable {
     var name: String { hookName }
     var section: String { "Hooks" }
 
-    /// The marker that v2 hooks contain for fragment injection.
-    static let extensionMarker = Constants.Hooks.extensionMarker
-
     func check() -> CheckResult {
         let hookPath = Environment().hooksDirectory.appendingPathComponent(hookName)
         guard FileManager.default.fileExists(atPath: hookPath.path) else {
@@ -158,11 +155,6 @@ struct HookCheck: DoctorCheck, Sendable {
         }
         guard FileManager.default.isExecutableFile(atPath: hookPath.path) else {
             return .fail("not executable")
-        }
-        // Verify hook has the extension marker (required for fragment injection)
-        if let content = try? String(contentsOf: hookPath, encoding: .utf8),
-           !content.contains(Self.extensionMarker) {
-            return .fail("legacy hook — missing extension marker, needs update")
         }
         return .pass("present and executable")
     }
@@ -187,8 +179,7 @@ struct HookCheck: DoctorCheck, Sendable {
             }
         }
 
-        // Legacy hook (exists, executable, but missing marker)
-        return .notFixable("Run 'mcs install' to replace legacy hook with current version")
+        return .notFixable("Run 'mcs install' to reinstall hooks")
     }
 }
 

--- a/Tests/MCSTests/CoreDoctorCheckTests.swift
+++ b/Tests/MCSTests/CoreDoctorCheckTests.swift
@@ -90,11 +90,6 @@ struct CommandFileCheckTests {
 
 @Suite("HookCheck")
 struct HookCheckTests {
-    @Test("extension marker constant matches hook template marker")
-    func extensionMarkerConstant() {
-        #expect(HookCheck.extensionMarker == "# --- mcs:hook-extensions ---")
-    }
-
     @Test("deriveDoctorCheck generates HookCheck for copyHook action")
     func derivedHookCheck() {
         let component = ComponentDefinition(


### PR DESCRIPTION
## Context

`mcs doctor` reports a false error for `continuous-learning-activator.sh`:
```
[ERROR] ✗ continuous-learning-activator.sh: legacy hook — missing extension marker, needs update
```

This happens on fresh installs. `HookCheck.check()` unconditionally verified every hook contains the `# --- mcs:hook-extensions ---` marker, but only `session_start.sh` is a fragment host. Standalone scripts like `continuous-learning-activator.sh` never need this marker.

Fragment injection correctness is already verified by dedicated checks (`ContinuousLearningHookFragmentCheck`, `HookContributionCheck`), and content integrity is covered by `ManifestFreshnessCheck`.

## Changes

- **Remove `extensionMarker` property and content check from `HookCheck`** — now only verifies existence + executability
- **Simplify `fix()` fallback** — generic message since only remaining fixable failure is permissions
- **Remove `extensionMarkerConstant` test** — references deleted property

Closes #39

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (227 tests)
- [ ] `mcs doctor` from a project directory — `continuous-learning-activator.sh` no longer reports false error