### PR TITLE
Fix manifest recording pre-substitution hash (#40)

### DIFF
--- a/Sources/mcs/Install/Installer.swift
+++ b/Sources/mcs/Install/Installer.swift
@@ -586,7 +586,7 @@ struct Installer {
                 ofItemAtPath: destURL.path
             )
 
-            recordManifest(&manifest, relativePath: source, sourceFile: sourceURL)
+            recordManifest(&manifest, relativePath: source, sourceFile: destURL)
             return true
         } catch {
             output.warn(error.localizedDescription)
@@ -618,7 +618,7 @@ struct Installer {
                 output.warn("Could not backup \(destURL.lastPathComponent): \(error.localizedDescription)")
             }
             try content.write(to: destURL, atomically: true, encoding: .utf8)
-            recordManifest(&manifest, relativePath: source, sourceFile: sourceURL)
+            recordManifest(&manifest, relativePath: source, sourceFile: destURL)
             return true
         } catch {
             output.warn(error.localizedDescription)


### PR DESCRIPTION
## Context

`mcs doctor` reports false freshness warnings (`commands/commit.md`, `commands/pr.md`, `hooks/session_start.sh`) because `copyHook()` and `copyCommand()` in `Installer.swift` record the SHA-256 hash of the **source** file (bundled resource with placeholders) instead of the **destination** file (installed, post-substitution). The manifest never matches what's on disk.

Fixes #40

## Changes

- `copyHook()` line 589: `sourceFile: sourceURL` → `sourceFile: destURL`
- `copyCommand()` line 621: `sourceFile: sourceURL` → `sourceFile: destURL`

## Testing Steps

1. `swift build && swift test` — 227 tests pass
2. `mcs install --all` then `mcs doctor` — File Freshness section shows all files matching manifest with zero warnings