### PR TITLE
feat: add swift-code-reviewer skill to iOS tech pack

### DIFF
--- a/Sources/mcs/Packs/iOS/IOSComponents.swift
+++ b/Sources/mcs/Packs/iOS/IOSComponents.swift
@@ -43,6 +43,20 @@ enum IOSComponents {
         supplementaryChecks: [XcodeBuildMCPSkillCheck()]
     )
 
+    static let swiftCodeReviewerSkill = ComponentDefinition(
+        id: "ios.skill.swift-code-reviewer",
+        displayName: "Swift Code Reviewer skill",
+        description: "Multi-layer code review for Swift and SwiftUI with quality, performance, and security analysis",
+        type: .skill,
+        packIdentifier: "ios",
+        dependencies: [],
+        isRequired: false,
+        installAction: .shellCommand(
+            command: "npx -y skills add Viniciuscarvalho/swift-code-reviewer-skill -g -a claude-code -y"
+        ),
+        supplementaryChecks: [SwiftCodeReviewerSkillCheck()]
+    )
+
     static let gitignore = ComponentDefinition(
         id: "ios.gitignore",
         displayName: "iOS gitignore entries",
@@ -58,6 +72,7 @@ enum IOSComponents {
         xcodeBuildMCP,
         sosumi,
         xcodeBuildMCPSkill,
+        swiftCodeReviewerSkill,
         gitignore,
     ]
 }

--- a/Sources/mcs/Packs/iOS/IOSDoctorChecks.swift
+++ b/Sources/mcs/Packs/iOS/IOSDoctorChecks.swift
@@ -22,6 +22,7 @@ enum IOSDoctorChecks {
             XcodeBuildMCPServerCheck(),
             SosumiServerCheck(),
             XcodeBuildMCPSkillCheck(),
+            SwiftCodeReviewerSkillCheck(),
             XcodeBuildMCPConfigCheck(),
             CLAUDELocalIOSSectionCheck(),
         ]
@@ -110,6 +111,24 @@ struct XcodeBuildMCPSkillCheck: DoctorCheck, Sendable {
             return .pass("Installed")
         }
         return .fail("xcodebuildmcp skill not installed")
+    }
+
+    func fix() -> FixResult {
+        .notFixable("Run 'mcs install' to install skills")
+    }
+}
+
+struct SwiftCodeReviewerSkillCheck: DoctorCheck, Sendable {
+    let section = "iOS"
+    let name = "swift-code-reviewer skill"
+
+    func check() -> CheckResult {
+        let skillsDir = Environment().skillsDirectory
+        let skillPath = skillsDir.appendingPathComponent("swift-code-reviewer-skill")
+        if FileManager.default.fileExists(atPath: skillPath.path) {
+            return .pass("Installed")
+        }
+        return .fail("swift-code-reviewer skill not installed")
     }
 
     func fix() -> FixResult {


### PR DESCRIPTION
## Summary

- Adds the [Swift Code Reviewer](https://github.com/Viniciuscarvalho/swift-code-reviewer-skill) agent skill as an optional component in the iOS tech pack
- Follows the existing `xcodeBuildMCPSkill` pattern: `shellCommand` install via `npx skills add`, with a supplementary doctor check
- New `SwiftCodeReviewerSkillCheck` verifies skill installation under `~/.claude/skills/swift-code-reviewer-skill/`

### What the skill does

Multi-layer code review for Swift and SwiftUI projects covering six dimensions:
- Swift quality (concurrency safety, error handling)
- SwiftUI patterns (state management, view composition)
- Performance optimization
- Security and data protection
- Architecture pattern compliance
- Project-specific standards from `.claude/CLAUDE.md`

### Changes

| File | Change |
|------|--------|
| `IOSComponents.swift` | New `swiftCodeReviewerSkill` component definition + added to `all` array |
| `IOSDoctorChecks.swift` | New `SwiftCodeReviewerSkillCheck` struct + added to `all` array |

## Test plan

- [x] `swift test` — all 238 tests pass
- [ ] `mcs install --pack ios` — verify the new skill appears in interactive selection
- [ ] `mcs doctor --pack ios` — verify the doctor check reports skill status
- [ ] `npx -y skills add Viniciuscarvalho/swift-code-reviewer-skill -g -a claude-code -y` — verify manual install works