### PR TITLE
Add --customize flag for component selection (#74 Phase 2)

### DIFF
--- a/Tests/MCSTests/SyncCommandTests.swift
+++ b/Tests/MCSTests/SyncCommandTests.swift
@@ -14,6 +14,7 @@ struct SyncCommandTests {
         #expect(cmd.dryRun == false)
         #expect(cmd.lock == false)
         #expect(cmd.update == false)
+        #expect(cmd.customize == false)
     }
 
     @Test("Parses path argument")
@@ -62,6 +63,12 @@ struct SyncCommandTests {
     func skipLockDefaultFalse() throws {
         let cmd = try SyncCommand.parse([])
         #expect(cmd.skipLock == false)
+    }
+
+    @Test("Parses --customize flag")
+    func parsesCustomize() throws {
+        let cmd = try SyncCommand.parse(["--customize"])
+        #expect(cmd.customize == true)
     }
 
     @Test("Parses combined flags with path")


### PR DESCRIPTION
## Summary

Implements Phase 2 of issue #74 — adds `--customize` flag to `mcs sync` for per-pack component-level selection.

- **`--customize` flag**: After pack multi-select, presents a second multi-select per pack showing individual components. Users can deselect optional components they don't want.
- **Exclusion-based persistence**: Excluded component IDs saved in `.mcs-project` as `excludedComponents` (packID -> [componentID]). New components added by pack updates are included by default.
- **Automatic respect in CI**: Non-interactive paths (`--pack`, `--all`) load persisted exclusions from ProjectState, so `mcs sync --customize` once + `mcs sync --pack ios` in CI honors the same selections.
- **Filtering across the pipeline**: Excluded components are skipped in `installProjectArtifacts`, `autoInstallGlobalDependencies`, and `composeProjectSettings` (hooks, plugins, settings merges).
- **Required components protected**: Components marked `isRequired` in the pack manifest cannot be deselected.

## Test plan

- [x] `swift build` compiles cleanly
- [x] `swift test` — 405 tests, 40 suites, all passing
- [x] `SyncCommandTests` — `--customize` flag parsing
- [x] `ProjectConfiguratorExcludedComponentsTests` — excluded component not installed, persistence round-trip, removal cleanup
- [x] Manual: `mcs sync --customize` shows per-pack component multi-select
- [x] Manual: Deselected components are skipped during sync
- [x] Manual: Re-running `mcs sync` (without --customize) respects previous exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)