### PR TITLE
Guard against corrupt state file in sync path

### DIFF
--- a/Sources/mcs/Core/MCSError.swift
+++ b/Sources/mcs/Core/MCSError.swift
@@ -8,6 +8,7 @@ enum MCSError: Error, LocalizedError {
     case dependencyMissing(String)
     case templateError(String)
     case configurationFailed(reason: String)
+    case corruptStateFile(path: String, underlying: String)
 
     var errorDescription: String? {
         switch self {
@@ -23,6 +24,8 @@ enum MCSError: Error, LocalizedError {
             return "Template error: \(message)"
         case .configurationFailed(let reason):
             return "Configuration failed: \(reason)"
+        case .corruptStateFile(let path, let underlying):
+            return "State file corrupt at \(path): \(underlying). Run 'mcs doctor --fix' to regenerate, or delete the file manually."
         }
     }
 }

--- a/Sources/mcs/Install/GlobalConfigurator.swift
+++ b/Sources/mcs/Install/GlobalConfigurator.swift
@@ -28,6 +28,9 @@ struct GlobalConfigurator {
         }
 
         let previousState = ProjectState(stateFile: environment.globalStateFile)
+        if let loadError = previousState.loadError {
+            throw MCSError.corruptStateFile(path: environment.globalStateFile.path, underlying: loadError.localizedDescription)
+        }
         let previousPacks = previousState.configuredPacks
 
         var number = 1
@@ -97,6 +100,10 @@ struct GlobalConfigurator {
         let selectedIDs = Set(packs.map(\.identifier))
 
         let state = ProjectState(stateFile: environment.globalStateFile)
+        if let loadError = state.loadError {
+            output.error("State file corrupt at \(environment.globalStateFile.path): \(loadError.localizedDescription). Run 'mcs doctor --fix' to regenerate, or delete the file manually.")
+            return
+        }
         let previousIDs = state.configuredPacks
 
         let removals = previousIDs.subtracting(selectedIDs)
@@ -220,6 +227,9 @@ struct GlobalConfigurator {
         let selectedIDs = Set(packs.map(\.identifier))
 
         var state = ProjectState(stateFile: environment.globalStateFile)
+        if let loadError = state.loadError {
+            throw MCSError.corruptStateFile(path: environment.globalStateFile.path, underlying: loadError.localizedDescription)
+        }
         let previousIDs = state.configuredPacks
 
         let removals = previousIDs.subtracting(selectedIDs)

--- a/Sources/mcs/Install/ProjectConfigurator.swift
+++ b/Sources/mcs/Install/ProjectConfigurator.swift
@@ -29,6 +29,11 @@ struct ProjectConfigurator {
 
         // Load previous state to pre-select previously configured packs
         let previousState = ProjectState(projectRoot: projectPath)
+        if let loadError = previousState.loadError {
+            let statePath = projectPath.appendingPathComponent(Constants.FileNames.claudeDirectory)
+                .appendingPathComponent(Constants.FileNames.mcsProject).path
+            throw MCSError.corruptStateFile(path: statePath, underlying: loadError.localizedDescription)
+        }
         let previousPacks = previousState.configuredPacks
 
         // Build selection groups — one group with all packs
@@ -101,6 +106,12 @@ struct ProjectConfigurator {
         let selectedIDs = Set(packs.map(\.identifier))
 
         let projectState = ProjectState(projectRoot: projectPath)
+        if let loadError = projectState.loadError {
+            let statePath = projectPath.appendingPathComponent(Constants.FileNames.claudeDirectory)
+                .appendingPathComponent(Constants.FileNames.mcsProject).path
+            output.error("State file corrupt at \(statePath): \(loadError.localizedDescription). Run 'mcs doctor --fix' to regenerate, or delete the file manually.")
+            return
+        }
         let previousIDs = projectState.configuredPacks
 
         let removals = previousIDs.subtracting(selectedIDs)
@@ -269,6 +280,11 @@ struct ProjectConfigurator {
 
         // Load previous state
         var projectState = ProjectState(projectRoot: projectPath)
+        if let loadError = projectState.loadError {
+            let statePath = projectPath.appendingPathComponent(Constants.FileNames.claudeDirectory)
+                .appendingPathComponent(Constants.FileNames.mcsProject).path
+            throw MCSError.corruptStateFile(path: statePath, underlying: loadError.localizedDescription)
+        }
         let previousIDs = projectState.configuredPacks
 
         let removals = previousIDs.subtracting(selectedIDs)


### PR DESCRIPTION
## Summary
- Adds `loadError` checks to all 6 `ProjectState` usage sites in `ProjectConfigurator` and `GlobalConfigurator` (`configure`, `dryRun`, `interactiveConfigure`)
- Adds `MCSError.corruptStateFile` case with an actionable error message pointing to `mcs doctor --fix`
- Throwing methods abort; non-throwing `dryRun` methods print the error and return early

Closes #83

## Test plan
- [x] `swift build` passes
- [x] All 454 tests pass
- [ ] Manual: corrupt `.claude/.mcs-project` with invalid JSON, run `mcs sync`, verify it aborts with the new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)