### PR TITLE
Bump version to 2026.2.25

### DIFF
--- a/Sources/mcs/CLI.swift
+++ b/Sources/mcs/CLI.swift
@@ -3,7 +3,7 @@ import ArgumentParser
 /// Single source of truth for the CLI version.
 /// Used in markers, sidecar files, and `--version` output.
 enum MCSVersion {
-    static let current = "2026.2.24"
+    static let current = "2026.2.25"
 }
 
 @main


### PR DESCRIPTION
## Summary
- Bump CalVer version from `2026.2.24` to `2026.2.25` for today's release

## Test plan
- [x] `swift build` passes
- [x] All 462 tests pass