### PR TITLE
Add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,6 @@ Only check items that apply to this PR. Delete irrelevant ones.
 - [ ] Any `fix()` implementation does cleanup/migration only — never installs or registers resources
 - [ ] State migrations are guarded by `isNeeded()` to stay idempotent with `mcs sync`
 - [ ] New file write/copy/delete paths use `PathContainment.safePath()` and handle the `nil` (escape) case
-- [ ] `CLAUDE.md` updated if architecture, commands, or subsystems changed
+- [ ] Docs updated if behavior changed (`CLAUDE.md`, `docs/`, `techpack.yaml` schema in `ExternalPackManifest.swift`)
 
 </details>


### PR DESCRIPTION
## Summary

Implements a modernized version of #49. The original issue proposed two templates (general + tech-pack), but since then the project moved to a pure engine model — all pack content lives in external repos. This adds a single, focused PR template.

## Changes

- Added `.github/PULL_REQUEST_TEMPLATE.md` with Summary/Changes/Test plan structure
- Included a collapsible engine checklist covering the five key code invariants:
  - `supplementaryDoctorChecks` for `.shellCommand` components
  - `fix()` responsibility boundary (cleanup/migration only)
  - `isNeeded()` guard for state migrations
  - `CLAUDE.md` currency for architecture changes
  - `MCSVersion.current` bump for user-visible changes
- Closed #49 with a comment explaining the architectural changes

## Test plan

- [x] Template renders correctly in GitHub PR form
- [x] `<details>` collapsible block expands properly
- [x] Issue #49 closed with explanatory comment