### PR TITLE
Bump version to 2026.2.26

### DIFF
--- a/Sources/mcs/CLI.swift
+++ b/Sources/mcs/CLI.swift
@@ -3,7 +3,7 @@ import ArgumentParser
 /// Single source of truth for the CLI version.
 /// Used in markers, sidecar files, and `--version` output.
 enum MCSVersion {
-    static let current = "2026.2.25"
+    static let current = "2026.2.26"
 }
 
 @main


### PR DESCRIPTION
## Summary
- Bump `MCSVersion.current` from `2026.2.25` to `2026.2.26`