### PR TITLE
Fix DoctorRunner silent registry fallback (#90)

### DIFF
--- a/Sources/mcs/Doctor/DoctorRunner.swift
+++ b/Sources/mcs/Doctor/DoctorRunner.swift
@@ -43,7 +43,12 @@ struct DoctorRunner {
             } else {
                 // No global state file yet — fall back to registry for backward compat
                 let packRegistry = PackRegistryFile(path: env.packsRegistry)
-                globallyConfiguredPackIDs = Set((try? packRegistry.load())?.packs.map(\.identifier) ?? [])
+                do {
+                    globallyConfiguredPackIDs = Set((try packRegistry.load()).packs.map(\.identifier))
+                } catch {
+                    output.warn("Could not read pack registry: \(error.localizedDescription) — no packs will be checked")
+                    globallyConfiguredPackIDs = []
+                }
             }
         } catch {
             // Corrupt state file — fall back to registry


### PR DESCRIPTION
## Summary

- Fixes #90 — `DoctorRunner` silently fell back to empty packs when the registry was corrupt and no global state file existed
- Replaced `try?` with `do/catch` + `output.warn()` on the `else` branch of `packRegistry.load()`, matching the existing error-handling pattern in the `catch` branch below

## Context

`DoctorRunner.swift:46` used `(try? packRegistry.load())?.packs … ?? []` in the code path where the global state file doesn't exist yet. If `~/.mcs/registry.yaml` was corrupt, the error was silently swallowed, doctor ran with zero packs, and reported everything fine — hiding the real problem.

The `catch` branch (corrupt state file) already handled the same scenario correctly with `do/catch` and a warning. This PR makes both branches consistent.

## Testing Steps

- [x] `swift build` passes
- [x] `swift test` — all 527 tests pass
- [x] Manual: remove `~/.mcs/global-state.json`, corrupt `~/.mcs/registry.yaml`, run `mcs doctor` — should see a warning instead of silent empty packs