### PR TITLE
Bump version to 2026.2.27

### DIFF
--- a/Sources/mcs/CLI.swift
+++ b/Sources/mcs/CLI.swift
@@ -3,7 +3,7 @@ import ArgumentParser
 /// Single source of truth for the CLI version.
 /// Used in markers, sidecar files, and `--version` output.
 enum MCSVersion {
-    static let current = "2026.2.26"
+    static let current = "2026.2.27"
 }
 
 @main


### PR DESCRIPTION
## Summary
- Bump `MCSVersion.current` from `2026.2.26` to `2026.2.27` (CalVer date-based)

## Test plan
- [ ] `swift build` succeeds
- [ ] `swift test` passes (version format test validates CalVer pattern)
- [ ] Tag `2026.2.27` pushed after merge