### PR TITLE
Extract duplicated peer dependency reporting (#96)

### DIFF
--- a/Sources/mcs/Commands/PackCommand.swift
+++ b/Sources/mcs/Commands/PackCommand.swift
@@ -314,18 +314,15 @@ struct AddPack: LockedCommand {
             manifest: manifest,
             registeredPacks: registryData.packs
         )
-        for result in peerResults where result.status != .satisfied {
-            switch result.status {
-            case .missing:
-                output.warn("Pack '\(manifest.identifier)' requires peer pack '\(result.peerPack)' (>= \(result.minVersion)) which is not registered.")
-                output.dimmed("  Install it with: mcs pack add <\(result.peerPack)-pack-url>")
-            case .versionTooLow(let actual):
-                output.warn("Pack '\(manifest.identifier)' requires peer pack '\(result.peerPack)' >= \(result.minVersion), but v\(actual) is registered.")
-                output.dimmed("  Update it with: mcs pack update \(result.peerPack)")
-            case .satisfied:
-                break // Filtered by `where` clause; required for exhaustive switch
+        ConfiguratorSupport.reportPeerDependencyIssues(
+            peerResults,
+            output: output,
+            severity: .warning,
+            missingVerb: "registered",
+            missingSuggestion: { _, peerPack in
+                "Install it with: mcs pack add <\(peerPack)-pack-url>"
             }
-        }
+        )
     }
 
     private func checkCollisions(

--- a/Sources/mcs/Install/ProjectConfigurator.swift
+++ b/Sources/mcs/Install/ProjectConfigurator.swift
@@ -284,19 +284,14 @@ struct ProjectConfigurator {
 
         // 0. Validate peer dependencies before making any changes
         let peerIssues = validatePeerDependencies(packs: packs)
-        if !peerIssues.isEmpty {
-            for issue in peerIssues {
-                switch issue.status {
-                case .missing:
-                    output.error("Pack '\(issue.packIdentifier)' requires peer pack '\(issue.peerPack)' (>= \(issue.minVersion)) which is not selected.")
-                    output.dimmed("  Either select '\(issue.peerPack)' or deselect '\(issue.packIdentifier)'.")
-                case .versionTooLow(let actual):
-                    output.error("Pack '\(issue.packIdentifier)' requires peer pack '\(issue.peerPack)' >= \(issue.minVersion), but v\(actual) is registered.")
-                    output.dimmed("  Update it with: mcs pack update \(issue.peerPack)")
-                case .satisfied:
-                    break
-                }
+        if ConfiguratorSupport.reportPeerDependencyIssues(
+            peerIssues,
+            output: output,
+            severity: .error,
+            missingSuggestion: { packID, peerPack in
+                "Either select '\(peerPack)' or deselect '\(packID)'."
             }
+        ) {
             throw MCSError.configurationFailed(
                 reason: "Unresolved peer dependencies. Fix the issues above and re-run mcs sync."
             )


### PR DESCRIPTION
## Summary

Fixes #96 — extracts the peer dependency error formatting switch statement (duplicated 3x) into a single shared `ConfiguratorSupport.reportPeerDependencyIssues()` method.

## Changes

- Add `PeerIssueSeverity` enum and `reportPeerDependencyIssues()` static method to `ConfiguratorSupport` with parameters for severity level, missing-state verb, and suggestion text
- Replace inline switch loops in `ProjectConfigurator` (lines 286–303) and `GlobalConfigurator` (lines 234–252) with shared method calls using `.error` severity
- Replace `PackCommand.checkPeerDependencies` body (lines 308–329) with shared method call using `.warning` severity and `missingVerb: "registered"`

## Test plan

- [x] `swift test` passes locally (535 tests)
- [x] Output behavior preserved: configurators use `error` severity with "select/deselect" suggestion and throw on failure; PackCommand uses `warn` severity with "mcs pack add" suggestion and continues