### PR TITLE
Extract duplicated dry-run summary logic (#97)

### DIFF
--- a/Sources/mcs/Install/ConfiguratorSupport.swift
+++ b/Sources/mcs/Install/ConfiguratorSupport.swift
@@ -107,7 +107,7 @@ enum ConfiguratorSupport {
         header: String,
         output: CLIOutput,
         artifactSummary: (_ pack: any TechPack) -> Void,
-        removalSummary: (_ packID: String, _ artifacts: PackArtifactRecord) -> Void
+        removalSummary: (_ artifacts: PackArtifactRecord) -> Void
     ) {
         let selectedIDs = Set(packs.map(\.identifier))
         let previousIDs = state.configuredPacks
@@ -138,7 +138,7 @@ enum ConfiguratorSupport {
             output.plain("")
             output.warn("- \(packID) (remove)")
             if let artifacts = state.artifacts(for: packID) {
-                removalSummary(packID, artifacts)
+                removalSummary(artifacts)
             } else {
                 output.dimmed("  No artifact record available")
             }

--- a/Sources/mcs/Install/GlobalConfigurator.swift
+++ b/Sources/mcs/Install/GlobalConfigurator.swift
@@ -100,8 +100,8 @@ struct GlobalConfigurator {
             state: state,
             header: "Plan (Global)",
             output: output,
-            artifactSummary: { printGlobalArtifactSummary($0) },
-            removalSummary: { _, artifacts in printRemovalSummary(artifacts) }
+            artifactSummary: printGlobalArtifactSummary,
+            removalSummary: printRemovalSummary
         )
     }
 

--- a/Sources/mcs/Install/ProjectConfigurator.swift
+++ b/Sources/mcs/Install/ProjectConfigurator.swift
@@ -104,8 +104,8 @@ struct ProjectConfigurator {
             state: projectState,
             header: "Plan",
             output: output,
-            artifactSummary: { printPackArtifactSummary($0) },
-            removalSummary: { _, artifacts in printRemovalSummary(artifacts) }
+            artifactSummary: printPackArtifactSummary,
+            removalSummary: printRemovalSummary
         )
     }
 


### PR DESCRIPTION
## Summary

Fixes #97 — extracts the duplicated dry-run orchestration flow (~55 lines each in `ProjectConfigurator` and `GlobalConfigurator`) into a single shared `ConfiguratorSupport.dryRunSummary()` method.

## Changes

- Add `dryRunSummary()` static method to `ConfiguratorSupport` that handles the full dry-run flow: compute diffs (additions/removals/updates), iterate and display summaries, print change counts
- Scope-specific artifact and removal display is provided via closures, keeping `printPackArtifactSummary`/`printGlobalArtifactSummary`/`printRemovalSummary` as private methods in their respective configurators
- Replace ~55-line `dryRun` bodies in both configurators with ~10-line delegations

## Test plan

- [x] `swift test` passes locally (535 tests, including 4 existing `ProjectConfiguratorTests` dry-run tests)
- [x] Output behavior preserved: header text, addition/removal/update formatting, change counts, "No changes made (dry run)" footer