### PR TITLE
Fix doctor false-positives for skipped global template sections

### DIFF
--- a/Sources/mcs/Doctor/DoctorRunner.swift
+++ b/Sources/mcs/Doctor/DoctorRunner.swift
@@ -174,8 +174,18 @@ struct DoctorRunner {
         nonComponentChecks += registry.supplementaryDoctorChecks(installedPacks: installedPackIDs)
         nonComponentChecks += standaloneDoctorChecks(installedPackIDs: installedPackIDs)
         if let root = projectRoot {
-            let context = ProjectDoctorContext(projectRoot: root, registry: registry)
-            nonComponentChecks += ProjectDoctorChecks.checks(context: context)
+            // Only add project-scoped checks if mcs was used in this project
+            let claudeLocalExists = FileManager.default.fileExists(
+                atPath: root.appendingPathComponent(Constants.FileNames.claudeLocalMD).path
+            )
+            let mcsProjectExists = FileManager.default.fileExists(
+                atPath: root.appendingPathComponent(Constants.FileNames.claudeDirectory)
+                    .appendingPathComponent(Constants.FileNames.mcsProject).path
+            )
+            if claudeLocalExists || mcsProjectExists {
+                let context = ProjectDoctorContext(projectRoot: root, registry: registry)
+                nonComponentChecks += ProjectDoctorChecks.checks(context: context)
+            }
         }
 
         // Global-scoped template freshness check (always runs, self-skips if no global CLAUDE.md)

--- a/Sources/mcs/Doctor/SectionValidator.swift
+++ b/Sources/mcs/Doctor/SectionValidator.swift
@@ -278,7 +278,18 @@ struct CLAUDEMDFreshnessCheck: DoctorCheck, Sendable {
                 errors.append("\(packID): failed to load templates — \(error.localizedDescription)")
                 continue
             }
+
+            // Only expect sections that were actually written to the file.
+            // When user skips sections with unresolved placeholders during
+            // global sync, those section IDs are removed from the artifact
+            // record's templateSections. If no artifact record exists
+            // (backward compat), include all sections.
+            let writtenSections = state.artifacts(for: packID)?.templateSections
+
             for contribution in templates {
+                if let writtenSections, !writtenSections.contains(contribution.sectionIdentifier) {
+                    continue
+                }
                 let rendered = TemplateEngine.substitute(
                     template: contribution.templateContent,
                     values: values,


### PR DESCRIPTION
## Summary

After #162 (global template support), `mcs doctor` falsely reports skipped template sections as missing, and `--fix` re-adds them with literal `__PLACEHOLDER__` text. Additionally, project-scoped checks appear as noisy skips when running doctor in projects where `mcs sync` was never used.

## Changes

- Filter `buildExpectedSections` in `CLAUDEMDFreshnessCheck` by `PackArtifactRecord.templateSections`, so sections the user intentionally skipped (unresolved placeholders during `mcs sync --global`) are excluded from expected sections
- Guard project-scoped doctor checks (`CLAUDEMDFreshnessCheck` for CLAUDE.local.md, `ProjectStateFileCheck`) behind filesystem existence of `CLAUDE.local.md` or `.mcs-project`
- Add 2 tests: skipped sections not reported as missing, fix does not add back skipped sections

## Test plan

- [x] `swift test` passes locally (552 tests, 46 suites)
- [x] `mcs doctor` from a project without `mcs sync` — no project-scoped skip noise
- [x] `mcs doctor` from MyClaudeSetup — global template freshness check passes

<details>
<summary>Checklist for engine changes</summary>

- [x] Docs updated if behavior changed (`CLAUDE.md`, `docs/`, `techpack.yaml` schema in `ExternalPackManifest.swift`) — no schema or behavioral doc changes needed

</details>