### PR TITLE
Fix CI cache key and release dependency chain

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
             .build/checkouts
             .build/repositories
             .build/workspace-state.json
-          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.swift') }}
           restore-keys: spm-${{ runner.os }}-
 
       - name: Resolve packages
@@ -42,7 +42,7 @@ jobs:
             .build/checkouts
             .build/repositories
             .build/workspace-state.json
-          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.swift') }}
           restore-keys: spm-${{ runner.os }}-
 
       - name: Test
@@ -61,7 +61,7 @@ jobs:
             .build/checkouts
             .build/repositories
             .build/workspace-state.json
-          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.swift') }}
           restore-keys: spm-${{ runner.os }}-
 
       - name: Build universal binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
 
   resolve:
     name: Resolve Dependencies
+    needs: verify-version
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -41,7 +42,7 @@ jobs:
             .build/checkouts
             .build/repositories
             .build/workspace-state.json
-          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.swift') }}
           restore-keys: spm-${{ runner.os }}-
 
       - name: Resolve packages
@@ -60,7 +61,7 @@ jobs:
             .build/checkouts
             .build/repositories
             .build/workspace-state.json
-          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.swift') }}
           restore-keys: spm-${{ runner.os }}-
 
       - name: Test
@@ -68,7 +69,7 @@ jobs:
 
   build-and-release:
     name: Build and Release
-    needs: [verify-version, resolve, test]
+    needs: [test]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -79,7 +80,7 @@ jobs:
             .build/checkouts
             .build/repositories
             .build/workspace-state.json
-          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.swift') }}
           restore-keys: spm-${{ runner.os }}-
 
       - name: Build universal binary


### PR DESCRIPTION
## Summary
- Fix SPM cache key: use `Package.swift` instead of `Package.resolved` (gitignored, so `hashFiles` returned empty string)
- Make `resolve` depend on `verify-version` in release workflow for fail-fast behavior
- Simplify `build-and-release` needs to `[test]` (transitive deps cover the rest)

Addresses Copilot review feedback from #173.

## Test plan
- CI passes with correct cache keys
- Release workflow fails fast if version mismatch is detected