### PR TITLE
[#183] Deduplicate export prompt keys for shared env vars

### DIFF
--- a/Sources/mcs/Export/ManifestBuilder.swift
+++ b/Sources/mcs/Export/ManifestBuilder.swift
@@ -119,6 +119,7 @@ struct ManifestBuilder {
         var brewHints: [String: String] = [:]
 
         // ── MCP Servers ───────────────────────────────────────────────────────
+        var seenPromptKeys: [String: Int] = [:]
         for server in config.mcpServers where options.selectedMCPServers.contains(server.name) {
             let id = "mcp-\(sanitizeID(server.name))"
 
@@ -133,9 +134,12 @@ struct ManifestBuilder {
             for key in server.env.keys.sorted() {
                 let value = server.env[key]!
                 if sensitiveNames.contains(key) {
-                    processedEnv[key] = "__\(key)__"
+                    let count = seenPromptKeys[key, default: 0] + 1
+                    seenPromptKeys[key] = count
+                    let promptKey = count == 1 ? key : "\(key)_\(count)"
+                    processedEnv[key] = "__\(promptKey)__"
                     prompts.append(ExternalPromptDefinition(
-                        key: key,
+                        key: promptKey,
                         type: .input,
                         label: "Enter value for \(key) (used by \(server.name) MCP server)",
                         defaultValue: nil,


### PR DESCRIPTION
## Summary

- When multiple MCP servers share the same sensitive env var name (e.g., both `figma` and `atlassian` servers have `API_KEY`), `ManifestBuilder.buildManifest()` now appends a sequential suffix (`API_KEY`, `API_KEY_2`, …) to keep prompt keys unique
- Placeholders in each server's env stay in sync with the suffixed prompt key so `TemplateEngine` substitution works correctly
- The exported pack is a starting point — users can consolidate or rename keys in the YAML afterward

## Test plan

- [x] New test `duplicatePromptKeysGetSuffix` verifies two servers sharing `API_KEY` produce unique prompt keys (`API_KEY`, `API_KEY_2`) with correct placeholders per server
- [x] Full YAML round-trip (build → write → load → normalize → validate) passes
- [x] All existing `ManifestBuilderTests` continue to pass (8/8)

Closes #183