### PR TITLE
[#187] Fix export hint path and ExportError conformance

### DIFF
--- a/Sources/mcs/Commands/ExportCommand.swift
+++ b/Sources/mcs/Commands/ExportCommand.swift
@@ -370,6 +370,7 @@ struct ExportCommand: ParsableCommand {
         config: ConfigurationDiscovery.DiscoveredConfiguration,
         output: CLIOutput
     ) {
+        let resolvedPath = URL(fileURLWithPath: outputDir).standardizedFileURL.path
         var hints: [String] = []
 
         // Check for MCP servers that might need brew (dynamic symlink resolution)
@@ -407,7 +408,7 @@ struct ExportCommand: ParsableCommand {
         output.plain("")
         output.info("Next steps:")
         output.plain("  1. Review the generated techpack.yaml")
-        output.plain("  2. Test with: mcs pack add \(outputDir)")
+        output.plain("  2. Test with: mcs pack add \(resolvedPath)")
         output.plain("  3. Share via git: push to a repository and use mcs pack add <url>")
     }
 

--- a/Sources/mcs/Export/PackWriter.swift
+++ b/Sources/mcs/Export/PackWriter.swift
@@ -83,12 +83,12 @@ struct PackWriter {
 
 // MARK: - Export Errors
 
-enum ExportError: Error, CustomStringConvertible {
+enum ExportError: Error, LocalizedError {
     case outputDirectoryExists(String)
     case noConfigurationFound
     case noProjectFound
 
-    var description: String {
+    var errorDescription: String? {
         switch self {
         case .outputDirectoryExists(let path):
             return "Output directory already exists: \(path). Remove it first or choose a different path."


### PR DESCRIPTION
## Context
Fixes #187. The `mcs export` command had two issues:
1. The post-export hint (`mcs pack add <path>`) printed the raw `outputDir` argument instead of the resolved absolute path, producing broken suggestions for relative paths.
2. `ExportError` used `CustomStringConvertible` instead of `LocalizedError`, so ArgumentParser could display generic error messages instead of the custom descriptions.

## Changes
- Pass resolved `outputURL.path` to `printPostExportHints()` and use it in the hint
- Change `ExportError` to conform to `LocalizedError` with `errorDescription`, matching `MCSError` and `ManifestError` conventions

## Testing Steps
- [ ] `swift build` passes
- [ ] Run `mcs export ./relative-path` and verify the hint shows an absolute path
- [ ] Trigger an `ExportError` (e.g. export to an existing directory) and verify the custom message displays