### PR TITLE
[#180] Dynamically resolve command paths

### DIFF
--- a/Sources/mcs/Commands/ExportCommand.swift
+++ b/Sources/mcs/Commands/ExportCommand.swift
@@ -71,10 +71,10 @@ struct ExportCommand: ParsableCommand {
                 identifier: identifier ?? "exported-pack",
                 displayName: identifier?.replacingOccurrences(of: "-", with: " ").capitalized ?? "Exported Pack",
                 description: "Exported Claude Code configuration",
-                author: gitAuthorName()
+                author: gitAuthorName(environment: env)
             )
         } else {
-            metadata = gatherMetadata(output: output)
+            metadata = gatherMetadata(environment: env, output: output)
         }
 
         // 5. Build manifest
@@ -344,14 +344,14 @@ struct ExportCommand: ParsableCommand {
 
     // MARK: - Metadata
 
-    private func gatherMetadata(output: CLIOutput) -> ManifestBuilder.Metadata {
+    private func gatherMetadata(environment env: Environment, output: CLIOutput) -> ManifestBuilder.Metadata {
         output.sectionHeader("Pack metadata:")
 
         let defaultID = identifier ?? "my-pack"
         let id = output.promptInline("Pack identifier", default: defaultID)
         let name = output.promptInline("Display name", default: id.replacingOccurrences(of: "-", with: " ").capitalized)
         let desc = output.promptInline("Description", default: "Exported Claude Code configuration")
-        let defaultAuthor = gitAuthorName()
+        let defaultAuthor = gitAuthorName(environment: env)
         let author = output.promptInline("Author", default: defaultAuthor)
 
         output.plain("")
@@ -414,8 +414,8 @@ struct ExportCommand: ParsableCommand {
 
     // MARK: - Helpers
 
-    private func gitAuthorName() -> String? {
-        let result = ShellRunner(environment: Environment()).run("/usr/bin/git", arguments: ["config", "user.name"])
-        return result.succeeded ? result.stdout.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) : nil
+    private func gitAuthorName(environment: Environment) -> String? {
+        let result = ShellRunner(environment: environment).run(environment.gitPath, arguments: ["config", "user.name"])
+        return result.succeeded ? result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) : nil
     }
 }

--- a/Sources/mcs/Core/Constants.swift
+++ b/Sources/mcs/Core/Constants.swift
@@ -20,6 +20,12 @@ enum Constants {
         /// The Claude Code configuration directory name.
         static let claudeDirectory = ".claude"
 
+        /// The Claude Code JSON configuration file.
+        static let claudeJSON = ".claude.json"
+
+        /// The global state file tracking globally-installed packs and artifacts.
+        static let globalState = "global-state.json"
+
         /// The process lock file preventing concurrent mcs execution.
         static let mcsLock = "lock"
     }
@@ -29,6 +35,12 @@ enum Constants {
     enum CLI {
         /// The `/usr/bin/env` path used to resolve commands from PATH.
         static let env = "/usr/bin/env"
+
+        /// The `/usr/bin/which` path for command resolution (POSIX bootstrap).
+        static let which = "/usr/bin/which"
+
+        /// The `/bin/bash` path for shell command execution.
+        static let bash = "/bin/bash"
 
         /// The Claude Code CLI binary name.
         static let claudeCommand = "claude"

--- a/Sources/mcs/Core/GitignoreManager.swift
+++ b/Sources/mcs/Core/GitignoreManager.swift
@@ -17,7 +17,7 @@ struct GitignoreManager: Sendable {
     /// Checks `git config core.excludesFile`, falls back to `~/.config/git/ignore`.
     func resolveGlobalGitignorePath() -> URL {
         let result = shell.run(
-            "/usr/bin/git",
+            shell.environment.gitPath,
             arguments: ["config", "--global", "core.excludesFile"]
         )
         if result.succeeded, !result.stdout.isEmpty {

--- a/Sources/mcs/Core/ShellRunner.swift
+++ b/Sources/mcs/Core/ShellRunner.swift
@@ -19,7 +19,7 @@ struct ShellRunner: Sendable {
 
     /// Check if a command exists on PATH.
     func commandExists(_ command: String) -> Bool {
-        let result = run("/usr/bin/which", arguments: [command])
+        let result = run(Constants.CLI.which, arguments: [command])
         return result.succeeded
     }
 
@@ -89,7 +89,7 @@ struct ShellRunner: Sendable {
         additionalEnvironment: [String: String] = [:]
     ) -> ShellResult {
         run(
-            "/bin/bash",
+            Constants.CLI.bash,
             arguments: ["-c", command],
             workingDirectory: workingDirectory,
             additionalEnvironment: additionalEnvironment

--- a/Sources/mcs/ExternalPack/ExternalDoctorCheck.swift
+++ b/Sources/mcs/ExternalPack/ExternalDoctorCheck.swift
@@ -46,7 +46,7 @@ struct ExternalCommandExistsCheck: DoctorCheck, Sendable {
             }
             resolved = command
         } else {
-            let which = shell.run("/usr/bin/which", arguments: [command])
+            let which = shell.run(Constants.CLI.which, arguments: [command])
             guard which.succeeded, !which.stdout.isEmpty else {
                 // Command not on PATH at all.
                 return .fail("not found")

--- a/Sources/mcs/ExternalPack/ScriptRunner.swift
+++ b/Sources/mcs/ExternalPack/ScriptRunner.swift
@@ -98,7 +98,7 @@ struct ScriptRunner: Sendable {
     ) -> ScriptResult {
         do {
             return try executeWithTimeout(
-                executable: "/bin/bash",
+                executable: Constants.CLI.bash,
                 arguments: ["-c", command],
                 workingDirectory: nil,
                 additionalEnvironment: ["MCS_VERSION": MCSVersion.current],

--- a/Sources/mcs/Install/LockfileOperations.swift
+++ b/Sources/mcs/Install/LockfileOperations.swift
@@ -49,7 +49,7 @@ struct LockfileOperations {
             }
 
             let result = shell.run(
-                "/usr/bin/git",
+                environment.gitPath,
                 arguments: ["-C", packPath.path, "checkout", locked.commitSHA]
             )
             if result.succeeded {
@@ -57,11 +57,11 @@ struct LockfileOperations {
             } else {
                 // Shallow-fetch latest, then retry checkout
                 _ = shell.run(
-                    "/usr/bin/git",
+                    environment.gitPath,
                     arguments: ["-C", packPath.path, "fetch", "--depth", "1", "origin"]
                 )
                 let retry = shell.run(
-                    "/usr/bin/git",
+                    environment.gitPath,
                     arguments: ["-C", packPath.path, "checkout", locked.commitSHA]
                 )
                 if retry.succeeded {

--- a/Sources/mcs/Install/ProjectSyncStrategy.swift
+++ b/Sources/mcs/Install/ProjectSyncStrategy.swift
@@ -232,7 +232,7 @@ struct ProjectSyncStrategy: SyncStrategy {
 
     private func resolveRepoName(shell: ShellRunner, output: CLIOutput) -> String {
         let remoteResult = shell.run(
-            "/usr/bin/git",
+            shell.environment.gitPath,
             arguments: ["-C", projectPath.path, "remote", "get-url", "origin"]
         )
         if remoteResult.succeeded, !remoteResult.stdout.isEmpty {
@@ -249,7 +249,7 @@ struct ProjectSyncStrategy: SyncStrategy {
 
     private func resolveProjectDirName(shell: ShellRunner) -> String {
         let gitResult = shell.run(
-            "/usr/bin/git",
+            shell.environment.gitPath,
             arguments: ["-C", projectPath.path, "rev-parse", "--show-toplevel"]
         )
         if gitResult.succeeded, !gitResult.stdout.isEmpty {

--- a/Tests/MCSTests/ShellRunnerTests.swift
+++ b/Tests/MCSTests/ShellRunnerTests.swift
@@ -64,7 +64,7 @@ struct ShellRunnerTests {
     @Test("additionalEnvironment is passed to subprocess")
     func additionalEnvironment() {
         let result = shell.run(
-            "/bin/bash",
+            Constants.CLI.bash,
             arguments: ["-c", "echo $MCS_TEST_VAR"],
             additionalEnvironment: ["MCS_TEST_VAR": "test_value"]
         )


### PR DESCRIPTION
## Summary

Resolves git and brew paths dynamically at startup via `/usr/bin/which` instead of hardcoding them, and centralizes remaining path strings as named constants. This makes the codebase refactor-friendly and supports non-standard tool installations (e.g. Homebrew via Nix, git from a custom prefix).

## Changes

- Add `Environment.resolveCommand(_:)` — lightweight Process-based resolver using `/usr/bin/which`, cached via `static let` for zero per-instance overhead
- Add `Environment.gitPath` stored property, resolved dynamically with `/usr/bin/git` fallback
- Refactor `Environment.brewPath` to resolve via `which brew`, deriving `brewPrefix` from the result with symlink resolution; falls back to arch-based defaults
- Add `Constants.CLI.which` and `Constants.CLI.bash` for the two remaining hardcoded system paths
- Add `Constants.FileNames.claudeJSON` and `Constants.FileNames.globalState` for previously inlined filename strings
- Replace 14 `/usr/bin/git` occurrences across 5 source files with `environment.gitPath`
- Replace 2 `/usr/bin/which` and 3 `/bin/bash` occurrences (including 1 in tests) with their constants
- Thread `Environment` through `ExportCommand.gitAuthorName()` and `gatherMetadata()` to eliminate a redundant `Environment()` construction

## Test plan

- [x] `swift test` passes locally (586 tests, 50 suites)
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)

<details>
<summary>Checklist for engine changes</summary>

- [x] Docs updated if behavior changed (`CLAUDE.md`, `docs/`, `techpack.yaml` schema in `ExternalPackManifest.swift`) — no behavior change, pure refactor

</details>