### PR TITLE
[#110] Deduplicate --all and --pack resolution in SyncCommand

### DIFF
--- a/Sources/mcs/Commands/SyncCommand.swift
+++ b/Sources/mcs/Commands/SyncCommand.swift
@@ -184,8 +184,9 @@ struct SyncCommand: LockedCommand {
         }
 
         let resolvedPacks: [any TechPack] = pack.compactMap { registry.pack(for: $0) }
+        let resolvedIDs = Set(resolvedPacks.map(\.identifier))
 
-        for id in pack where registry.pack(for: id) == nil {
+        for id in pack where !resolvedIDs.contains(id) {
             output.warn("Unknown tech pack: \(id)")
         }
 


### PR DESCRIPTION
## Summary

Extract shared helpers for the duplicated `--all` and `--pack` resolution pattern in `SyncCommand`. Both `performGlobal` and `performProject` had near-identical branches (~40 lines each) for pack resolution, header output, and configure/dryRun dispatch.

## Changes

- Extract `resolvePacks(from:output:)` — handles both `--all` (all registered packs) and `--pack` (resolve by ID, warn unknowns) paths with validation
- Extract `runSync(configurator:packs:scopeLabel:targetLabel:targetPath:excludedComponents:output:)` — handles header printing and configure/dryRun dispatch
- Simplify `performGlobal` and `performProject` to delegate to shared helpers, keeping only scope-specific setup

## Test plan

- [x] `swift test` passes locally
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)