### PR TITLE
Remove dead .claude/lock gitignore core entry

### DIFF
--- a/Sources/mcs/Core/GitignoreManager.swift
+++ b/Sources/mcs/Core/GitignoreManager.swift
@@ -10,7 +10,6 @@ struct GitignoreManager: Sendable {
         Constants.FileNames.claudeDirectory,
         "*.local.*",
         "\(Constants.FileNames.claudeDirectory)/\(Constants.FileNames.mcsProject)",
-        "\(Constants.FileNames.claudeDirectory)/\(Constants.FileNames.mcsLock)",
     ]
 
     /// Resolve the global gitignore file path.


### PR DESCRIPTION
## Context
`GitignoreManager.coreEntries` included `.claude/lock` — intended for the POSIX process lock. However, the process lock lives at `~/.mcs/lock`, never inside a project's `.claude/` directory. The entry was unreachable dead weight in the global gitignore.

## Changes
- Remove the `.claude/lock` entry from `coreEntries` in `GitignoreManager.swift`

## Testing
- `swift build` succeeds
- Full test suite passes (593 tests)