### PR TITLE
[#114] Remove default registry parameter from DoctorRunner.init

### DIFF
--- a/Sources/mcs/Doctor/DoctorRunner.swift
+++ b/Sources/mcs/Doctor/DoctorRunner.swift
@@ -37,7 +37,7 @@ struct DoctorRunner {
         skipConfirmation: Bool = false,
         packFilter: String? = nil,
         globalOnly: Bool = false,
-        registry: TechPackRegistry = .shared
+        registry: TechPackRegistry
     ) {
         self.fixMode = fixMode
         self.skipConfirmation = skipConfirmation


### PR DESCRIPTION
## Summary
- Remove `= .shared` default from `DoctorRunner.init(registry:)` so callers must explicitly provide a `TechPackRegistry`
- Prevents silent empty-registry trap where pack-derived doctor checks would vanish if a caller forgot to pass a loaded registry
- The sole existing caller (`DoctorCommand.perform()`) already passes the registry explicitly — no behavior change

## Test plan
- [x] `swift build` succeeds (no call site relies on the removed default)
- [x] All 641 tests pass

Closes #114