### PR TITLE
[#157] Remove legacy top-level gitignoreEntries from manifest

### DIFF
--- a/Sources/mcs/Doctor/CoreDoctorChecks.swift
+++ b/Sources/mcs/Doctor/CoreDoctorChecks.swift
@@ -186,13 +186,6 @@ struct HookCheck: DoctorCheck, Sendable {
 struct GitignoreCheck: DoctorCheck, Sendable {
     var name: String { "Global gitignore" }
     var section: String { "Gitignore" }
-    let registry: TechPackRegistry
-    let installedPackIDs: Set<String>
-
-    init(registry: TechPackRegistry = .shared, installedPackIDs: Set<String> = []) {
-        self.registry = registry
-        self.installedPackIDs = installedPackIDs
-    }
 
     func check() -> CheckResult {
         let shell = ShellRunner(environment: Environment())
@@ -204,7 +197,6 @@ struct GitignoreCheck: DoctorCheck, Sendable {
             return .fail("global gitignore not found")
         }
         let allEntries = GitignoreManager.coreEntries
-            + registry.gitignoreEntries(installedPacks: installedPackIDs)
         var missing: [String] = []
         for entry in allEntries {
             if !content.contains(entry) {
@@ -222,9 +214,6 @@ struct GitignoreCheck: DoctorCheck, Sendable {
         let gitignoreManager = GitignoreManager(shell: shell)
         do {
             try gitignoreManager.addCoreEntries()
-            for entry in registry.gitignoreEntries(installedPacks: installedPackIDs) {
-                try gitignoreManager.addEntry(entry)
-            }
             return .fixed("added missing entries")
         } catch {
             return .failed(error.localizedDescription)

--- a/Sources/mcs/Doctor/DoctorRunner.swift
+++ b/Sources/mcs/Doctor/DoctorRunner.swift
@@ -128,7 +128,7 @@ struct DoctorRunner {
 
         // Layers 3-5: Standalone and project-scoped checks (scope-independent)
         var nonComponentChecks: [any DoctorCheck] = []
-        nonComponentChecks += standaloneDoctorChecks(installedPackIDs: allPackIDs)
+        nonComponentChecks += standaloneDoctorChecks()
         if !globalOnly, let root = projectRoot {
             // Only add project-scoped checks if mcs was used in this project
             let claudeLocalExists = FileManager.default.fileExists(
@@ -297,11 +297,11 @@ struct DoctorRunner {
     // MARK: - Standalone checks (not tied to any component)
 
     /// Checks that cannot be derived from any ComponentDefinition.
-    private func standaloneDoctorChecks(installedPackIDs: Set<String>) -> [any DoctorCheck] {
+    private func standaloneDoctorChecks() -> [any DoctorCheck] {
         var checks: [any DoctorCheck] = []
 
-        // Gitignore (cross-component aggregation — engine-level)
-        checks.append(GitignoreCheck(registry: registry, installedPackIDs: installedPackIDs))
+        // Gitignore (core entries)
+        checks.append(GitignoreCheck())
 
         // Project index (cross-project tracking)
         checks.append(ProjectIndexCheck())

--- a/Sources/mcs/Export/ManifestBuilder.swift
+++ b/Sources/mcs/Export/ManifestBuilder.swift
@@ -289,7 +289,6 @@ struct ManifestBuilder {
             minMCSVersion: nil,
             components: components.isEmpty ? nil : components,
             templates: templates.isEmpty ? nil : templates,
-            gitignoreEntries: nil,
             prompts: prompts.isEmpty ? nil : prompts,
             configureProject: nil,
             supplementaryDoctorChecks: nil

--- a/Sources/mcs/ExternalPack/ExternalPackAdapter.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackAdapter.swift
@@ -59,12 +59,6 @@ struct ExternalPackAdapter: TechPack {
         manifest.templates?.map(\.sectionIdentifier) ?? []
     }
 
-    // MARK: - Gitignore Entries
-
-    var gitignoreEntries: [String] {
-        manifest.gitignoreEntries ?? []
-    }
-
     // MARK: - Doctor Checks
 
     var supplementaryDoctorChecks: [any DoctorCheck] {

--- a/Sources/mcs/ExternalPack/ExternalPackManifest.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackManifest.swift
@@ -13,7 +13,6 @@ struct ExternalPackManifest: Codable, Sendable {
     let minMCSVersion: String?
     let components: [ExternalComponentDefinition]?
     let templates: [ExternalTemplateDefinition]?
-    let gitignoreEntries: [String]?
     let prompts: [ExternalPromptDefinition]?
     let configureProject: ExternalConfigureProject?
     let supplementaryDoctorChecks: [ExternalDoctorCheckDefinition]?
@@ -206,7 +205,6 @@ extension ExternalPackManifest {
             minMCSVersion: minMCSVersion,
             components: normalizedComponents,
             templates: normalizedTemplates,
-            gitignoreEntries: gitignoreEntries,
             prompts: prompts,
             configureProject: configureProject,
             supplementaryDoctorChecks: supplementaryDoctorChecks

--- a/Sources/mcs/Install/ComponentExecutor.swift
+++ b/Sources/mcs/Install/ComponentExecutor.swift
@@ -112,21 +112,6 @@ struct ComponentExecutor {
         }
     }
 
-    // MARK: - Pack Post-Processing
-
-    /// Add a pack's gitignore entries to the global gitignore.
-    func addPackGitignoreEntries(from pack: any TechPack) {
-        guard !pack.gitignoreEntries.isEmpty else { return }
-        let manager = GitignoreManager(shell: shell)
-        for entry in pack.gitignoreEntries {
-            do {
-                try manager.addEntry(entry)
-            } catch {
-                output.warn("Failed to add gitignore entry '\(entry)': \(error.localizedDescription)")
-            }
-        }
-    }
-
     // MARK: - Copy Pack File
 
     /// Copy files from an external pack checkout to the appropriate Claude directory.

--- a/Sources/mcs/Install/Configurator.swift
+++ b/Sources/mcs/Install/Configurator.swift
@@ -272,17 +272,6 @@ struct Configurator {
 
         // 9. Ensure gitignore entries
         try ConfiguratorSupport.ensureGitignoreEntries(shell: shell)
-        let gitignoreExec = makeExecutor()
-        for pack in packs {
-            gitignoreExec.addPackGitignoreEntries(from: pack)
-            // Merge legacy top-level gitignore entries with any component-recorded ones
-            if !pack.gitignoreEntries.isEmpty, var artifacts = state.artifacts(for: pack.identifier) {
-                let existing = Set(artifacts.gitignoreEntries)
-                let newEntries = pack.gitignoreEntries.filter { !existing.contains($0) }
-                artifacts.gitignoreEntries.append(contentsOf: newEntries)
-                state.setArtifacts(artifacts, for: pack.identifier)
-            }
-        }
 
         // 10. Final state save
         do {

--- a/Sources/mcs/Install/PackInstaller.swift
+++ b/Sources/mcs/Install/PackInstaller.swift
@@ -77,9 +77,6 @@ struct PackInstaller {
             }
         }
 
-        // Post-processing: gitignore entries
-        executor.addPackGitignoreEntries(from: pack)
-
         return allSucceeded
     }
 

--- a/Sources/mcs/TechPack/TechPack.swift
+++ b/Sources/mcs/TechPack/TechPack.swift
@@ -44,7 +44,6 @@ protocol TechPack: Sendable {
     /// Section identifiers for template contributions, available without reading
     /// content files from disk. Used for artifact tracking and display.
     var templateSectionIdentifiers: [String] { get }
-    var gitignoreEntries: [String] { get }
     /// Doctor checks that cannot be auto-derived from components.
     /// For pack-level or project-level concerns (e.g. Xcode CLT, config files).
     var supplementaryDoctorChecks: [any DoctorCheck] { get }

--- a/Sources/mcs/TechPack/TechPackRegistry.swift
+++ b/Sources/mcs/TechPack/TechPackRegistry.swift
@@ -32,12 +32,6 @@ struct TechPackRegistry: Sendable {
             .flatMap { $0.supplementaryDoctorChecks }
     }
 
-    /// Get gitignore entries only for installed packs.
-    func gitignoreEntries(installedPacks ids: Set<String>) -> [String] {
-        availablePacks.filter { ids.contains($0.identifier) }
-            .flatMap { $0.gitignoreEntries }
-    }
-
     /// Get template contributions for a specific pack.
     func templateContributions(for packIdentifier: String) throws -> [TemplateContribution] {
         try pack(for: packIdentifier)?.templates ?? []

--- a/Tests/MCSTests/CLAUDELocalFreshnessCheckTests.swift
+++ b/Tests/MCSTests/CLAUDELocalFreshnessCheckTests.swift
@@ -626,7 +626,6 @@ private struct StubTechPack: TechPack {
     let description: String = "A stub pack for testing"
     let components: [ComponentDefinition] = []
     let templates: [TemplateContribution]
-    let gitignoreEntries: [String] = []
     let supplementaryDoctorChecks: [any DoctorCheck] = []
 
     func configureProject(at path: URL, context: ProjectConfigContext) throws {}
@@ -640,7 +639,6 @@ private struct ThrowingTechPack: TechPack {
     var templates: [TemplateContribution] {
         get throws { throw TestError.templateLoadFailed }
     }
-    let gitignoreEntries: [String] = []
     let supplementaryDoctorChecks: [any DoctorCheck] = []
 
     func configureProject(at path: URL, context: ProjectConfigContext) throws {}

--- a/Tests/MCSTests/CrossPackPromptResolverTests.swift
+++ b/Tests/MCSTests/CrossPackPromptResolverTests.swift
@@ -246,7 +246,6 @@ struct CrossPackPromptResolverTests {
             minMCSVersion: nil,
             components: [],
             templates: nil,
-            gitignoreEntries: nil,
             prompts: [
                 ExternalPromptDefinition(
                     key: "PROJECT", type: .fileDetect,
@@ -618,7 +617,6 @@ private struct PromptMockPack: TechPack {
     let description: String = "Mock pack for prompt tests"
     let components: [ComponentDefinition]
     let templates: [TemplateContribution] = []
-    let gitignoreEntries: [String] = []
     let supplementaryDoctorChecks: [any DoctorCheck] = []
     private let prompts: [ExternalPromptDefinition]
 

--- a/Tests/MCSTests/ExternalPackAdapterTests.swift
+++ b/Tests/MCSTests/ExternalPackAdapterTests.swift
@@ -1,10 +1,9 @@
 import Foundation
-import Testing
 @testable import mcs
+import Testing
 
 @Suite("ExternalPackAdapter")
 struct ExternalPackAdapterTests {
-
     // MARK: - Identity
 
     @Test("Adapter exposes manifest identity fields")
@@ -38,7 +37,7 @@ struct ExternalPackAdapterTests {
                     scope: nil
                 )),
                 doctorChecks: nil
-            ),
+            )
         ])
         let (adapter, _) = try makeAdapter(manifest: manifest)
         let components = adapter.components
@@ -48,7 +47,7 @@ struct ExternalPackAdapterTests {
         #expect(component.displayName == "Test MCP")
         #expect(component.type == .mcpServer)
         #expect(component.packIdentifier == "test-pack")
-        if case .mcpServer(let config) = component.installAction {
+        if case let .mcpServer(config) = component.installAction {
             #expect(config.name == "test-server")
             #expect(config.command == "npx")
             #expect(config.args == ["-y", "test@latest"])
@@ -79,11 +78,11 @@ struct ExternalPackAdapterTests {
                     scope: nil
                 )),
                 doctorChecks: nil
-            ),
+            )
         ])
         let (adapter, _) = try makeAdapter(manifest: manifest)
         let component = adapter.components[0]
-        if case .mcpServer(let config) = component.installAction {
+        if case let .mcpServer(config) = component.installAction {
             // HTTP transport uses the .http() convenience
             #expect(config.name == "http-server")
             #expect(config.command == "http")
@@ -106,11 +105,11 @@ struct ExternalPackAdapterTests {
                 hookEvent: nil,
                 installAction: .brewInstall(package: "node"),
                 doctorChecks: nil
-            ),
+            )
         ])
         let (adapter, _) = try makeAdapter(manifest: manifest)
         let component = adapter.components[0]
-        if case .brewInstall(let package) = component.installAction {
+        if case let .brewInstall(package) = component.installAction {
             #expect(package == "node")
         } else {
             Issue.record("Expected .brewInstall action")
@@ -130,11 +129,11 @@ struct ExternalPackAdapterTests {
                 hookEvent: nil,
                 installAction: .shellCommand(command: "echo hello"),
                 doctorChecks: nil
-            ),
+            )
         ])
         let (adapter, _) = try makeAdapter(manifest: manifest)
         let component = adapter.components[0]
-        if case .shellCommand(let command) = component.installAction {
+        if case let .shellCommand(command) = component.installAction {
             #expect(command == "echo hello")
         } else {
             Issue.record("Expected .shellCommand action")
@@ -158,11 +157,11 @@ struct ExternalPackAdapterTests {
                     fileType: .skill
                 )),
                 doctorChecks: nil
-            ),
+            )
         ])
         let (adapter, packPath) = try makeAdapter(manifest: manifest)
         let component = adapter.components[0]
-        if case .copyPackFile(let source, let destination, let fileType) = component.installAction {
+        if case let .copyPackFile(source, destination, fileType) = component.installAction {
             #expect(source == packPath.appendingPathComponent("resources/my-skill"))
             #expect(destination == "my-skill")
             #expect(fileType == .skill)
@@ -188,12 +187,12 @@ struct ExternalPackAdapterTests {
                     fileType: .agent
                 )),
                 doctorChecks: nil
-            ),
+            )
         ])
         let (adapter, packPath) = try makeAdapter(manifest: manifest)
         let component = adapter.components[0]
         #expect(component.type == .agent)
-        if case .copyPackFile(let source, let destination, let fileType) = component.installAction {
+        if case let .copyPackFile(source, destination, fileType) = component.installAction {
             #expect(source == packPath.appendingPathComponent("agents/code-reviewer.md"))
             #expect(destination == "code-reviewer.md")
             #expect(fileType == .agent)
@@ -215,7 +214,7 @@ struct ExternalPackAdapterTests {
                 hookEvent: nil,
                 installAction: .gitignoreEntries(entries: [".test"]),
                 doctorChecks: nil
-            ),
+            )
         ])
         let (adapter, _) = try makeAdapter(manifest: manifest)
         #expect(adapter.components[0].packIdentifier == "test-pack")
@@ -235,7 +234,7 @@ struct ExternalPackAdapterTests {
                 hookEvent: nil,
                 installAction: .shellCommand(command: "echo a"),
                 doctorChecks: nil
-            ),
+            )
         ])
         let (adapter, _) = try makeAdapter(manifest: manifest)
         #expect(adapter.components[0].dependencies == ["core.node"])
@@ -269,9 +268,8 @@ struct ExternalPackAdapterTests {
                     sectionIdentifier: "test-pack",
                     placeholders: ["__PROJECT__"],
                     contentFile: "templates/ios.md"
-                ),
+                )
             ],
-            gitignoreEntries: nil,
             prompts: nil,
             configureProject: nil,
             supplementaryDoctorChecks: nil
@@ -283,34 +281,6 @@ struct ExternalPackAdapterTests {
         #expect(templates[0].sectionIdentifier == "test-pack")
         #expect(templates[0].templateContent.contains("__PROJECT__"))
         #expect(templates[0].placeholders == ["__PROJECT__"])
-    }
-
-    // MARK: - Gitignore
-
-    @Test("Adapter returns gitignore entries")
-    func gitignoreEntries() throws {
-        let manifest = ExternalPackManifest(
-            schemaVersion: 1,
-            identifier: "test-pack",
-            displayName: "Test Pack",
-            description: "desc",
-            author: nil,
-            minMCSVersion: nil,
-            components: nil,
-            templates: nil,
-            gitignoreEntries: [".xcodebuildmcp", ".build"],
-            prompts: nil,
-            configureProject: nil,
-            supplementaryDoctorChecks: nil
-        )
-        let adapter = ExternalPackAdapter(manifest: manifest, packPath: URL(fileURLWithPath: "/tmp"))
-        #expect(adapter.gitignoreEntries == [".xcodebuildmcp", ".build"])
-    }
-
-    @Test("Adapter returns empty gitignore when nil")
-    func emptyGitignore() throws {
-        let (adapter, _) = try makeAdapter(manifest: minimalManifest())
-        #expect(adapter.gitignoreEntries.isEmpty)
     }
 
     // MARK: - Path Traversal via Templates
@@ -342,7 +312,6 @@ struct ExternalPackAdapterTests {
                     contentFile: "../secret.md"
                 )
             ],
-            gitignoreEntries: nil,
             prompts: nil,
             configureProject: nil,
             supplementaryDoctorChecks: nil
@@ -387,7 +356,6 @@ struct ExternalPackAdapterTests {
                     contentFile: "templates/link.md"
                 )
             ],
-            gitignoreEntries: nil,
             prompts: nil,
             configureProject: nil,
             supplementaryDoctorChecks: nil
@@ -423,7 +391,7 @@ struct ExternalPackAdapterTests {
                     fileType: .generic
                 )),
                 doctorChecks: nil
-            ),
+            )
         ])
         let adapter = ExternalPackAdapter(manifest: manifest, packPath: packDir)
         #expect(adapter.components.isEmpty)
@@ -463,7 +431,7 @@ struct ExternalPackAdapterTests {
                     fileType: .generic
                 )),
                 doctorChecks: nil
-            ),
+            )
         ])
         let adapter = ExternalPackAdapter(manifest: manifest, packPath: packDir)
         #expect(adapter.components.isEmpty)
@@ -490,7 +458,7 @@ struct ExternalPackAdapterTests {
                 hookEvent: nil,
                 installAction: .settingsFile(source: "../../etc/passwd"),
                 doctorChecks: nil
-            ),
+            )
         ])
         let adapter = ExternalPackAdapter(manifest: manifest, packPath: packDir)
         #expect(adapter.components.isEmpty)
@@ -525,7 +493,6 @@ struct ExternalPackAdapterTests {
                     contentFile: "templates/section.md"
                 )
             ],
-            gitignoreEntries: nil,
             prompts: nil,
             configureProject: nil,
             supplementaryDoctorChecks: nil
@@ -550,13 +517,12 @@ struct ExternalPackAdapterTests {
             minMCSVersion: nil,
             components: nil,
             templates: nil,
-            gitignoreEntries: nil,
             prompts: [
                 ExternalPromptDefinition(
                     key: "ALREADY_RESOLVED", type: .input,
                     label: "This should be skipped", defaultValue: "default",
                     options: nil, detectPatterns: nil, scriptCommand: nil
-                ),
+                )
             ],
             configureProject: nil,
             supplementaryDoctorChecks: nil
@@ -588,7 +554,6 @@ struct ExternalPackAdapterTests {
             minMCSVersion: nil,
             components: nil,
             templates: nil,
-            gitignoreEntries: nil,
             prompts: [
                 ExternalPromptDefinition(
                     key: "PREFIX", type: .input,
@@ -599,7 +564,7 @@ struct ExternalPackAdapterTests {
                     key: "PROJECT", type: .fileDetect,
                     label: "Xcode project", defaultValue: nil,
                     options: nil, detectPatterns: ["*.xcodeproj"], scriptCommand: nil
-                ),
+                )
             ],
             configureProject: nil,
             supplementaryDoctorChecks: nil
@@ -642,7 +607,6 @@ struct ExternalPackAdapterTests {
             minMCSVersion: nil,
             components: nil,
             templates: nil,
-            gitignoreEntries: nil,
             prompts: nil,
             configureProject: nil,
             supplementaryDoctorChecks: nil
@@ -661,7 +625,6 @@ struct ExternalPackAdapterTests {
             minMCSVersion: nil,
             components: components,
             templates: nil,
-            gitignoreEntries: nil,
             prompts: nil,
             configureProject: nil,
             supplementaryDoctorChecks: nil

--- a/Tests/MCSTests/ExternalPackManifestTests.swift
+++ b/Tests/MCSTests/ExternalPackManifestTests.swift
@@ -57,8 +57,6 @@ struct ExternalPackManifestTests {
                 placeholders:
                   - __PROJECT__
                 contentFile: templates/section.md
-            gitignoreEntries:
-              - .my-pack
             prompts:
               - key: project_name
                 type: input
@@ -114,9 +112,6 @@ struct ExternalPackManifestTests {
         #expect(manifest.templates?[0].placeholders == ["__PROJECT__"])
         #expect(manifest.templates?[0].contentFile == "templates/section.md")
 
-        // Gitignore entries
-        #expect(manifest.gitignoreEntries == [".my-pack"])
-
         // Prompts
         #expect(manifest.prompts?.count == 2)
         #expect(manifest.prompts?[0].key == "project_name")
@@ -163,7 +158,6 @@ struct ExternalPackManifestTests {
         #expect(manifest.minMCSVersion == nil)
         #expect(manifest.components == nil)
         #expect(manifest.templates == nil)
-        #expect(manifest.gitignoreEntries == nil)
         #expect(manifest.prompts == nil)
         #expect(manifest.configureProject == nil)
         #expect(manifest.supplementaryDoctorChecks == nil)
@@ -1779,7 +1773,6 @@ struct ExternalPackManifestTests {
                     contentFile: "t.md"
                 )
             ],
-            gitignoreEntries: nil,
             prompts: nil,
             configureProject: nil,
             supplementaryDoctorChecks: nil

--- a/Tests/MCSTests/PackWriterTests.swift
+++ b/Tests/MCSTests/PackWriterTests.swift
@@ -26,7 +26,6 @@ struct PackWriterTests {
             minMCSVersion: nil,
             components: nil,
             templates: nil,
-            gitignoreEntries: nil,
             prompts: nil,
             configureProject: nil,
             supplementaryDoctorChecks: nil

--- a/Tests/MCSTests/ProjectConfiguratorTests.swift
+++ b/Tests/MCSTests/ProjectConfiguratorTests.swift
@@ -968,7 +968,6 @@ private struct MockTechPack: TechPack {
     let description: String = "Mock pack for testing"
     let components: [ComponentDefinition]
     let templates: [TemplateContribution]
-    let gitignoreEntries: [String]
     let supplementaryDoctorChecks: [any DoctorCheck]
 
     init(
@@ -976,14 +975,12 @@ private struct MockTechPack: TechPack {
         displayName: String,
         components: [ComponentDefinition] = [],
         templates: [TemplateContribution] = [],
-        gitignoreEntries: [String] = [],
         supplementaryDoctorChecks: [any DoctorCheck] = []
     ) {
         self.identifier = identifier
         self.displayName = displayName
         self.components = components
         self.templates = templates
-        self.gitignoreEntries = gitignoreEntries
         self.supplementaryDoctorChecks = supplementaryDoctorChecks
     }
 

--- a/Tests/MCSTests/ResourceRefCounterTests.swift
+++ b/Tests/MCSTests/ResourceRefCounterTests.swift
@@ -13,7 +13,6 @@ private struct StubTechPack: TechPack {
     let components: [ComponentDefinition]
     var templates: [TemplateContribution] { [] }
     var templateSectionIdentifiers: [String] { [] }
-    var gitignoreEntries: [String] { [] }
     var supplementaryDoctorChecks: [any DoctorCheck] { [] }
     func configureProject(at _: URL, context _: ProjectConfigContext) throws {}
 }

--- a/Tests/MCSTests/TechPackRegistryTests.swift
+++ b/Tests/MCSTests/TechPackRegistryTests.swift
@@ -33,12 +33,6 @@ struct TechPackRegistryTests {
         #expect(checks.isEmpty)
     }
 
-    @Test("gitignoreEntries returns empty when no packs installed")
-    func gitignoreEntriesEmpty() {
-        let entries = TechPackRegistry.shared.gitignoreEntries(installedPacks: [])
-        #expect(entries.isEmpty)
-    }
-
     // MARK: - Template contributions
 
     @Test("templateContributions returns templates for registered pack")
@@ -120,16 +114,6 @@ struct TechPackRegistryTests {
         #expect(checks.first?.name == "test-check")
     }
 
-    @Test("gitignoreEntries returns entries for registered pack")
-    func gitignoreEntriesWithPack() {
-        let fakePack = FakeTechPack(
-            identifier: "test-pack",
-            gitignoreEntries: [".testdir"]
-        )
-        let registry = TechPackRegistry(packs: [fakePack])
-        let entries = registry.gitignoreEntries(installedPacks: ["test-pack"])
-        #expect(entries.contains(".testdir"))
-    }
 }
 
 // MARK: - Test Helper
@@ -140,20 +124,17 @@ private struct FakeTechPack: TechPack {
     let description: String = "A fake pack for testing"
     let components: [ComponentDefinition]
     let templates: [TemplateContribution]
-    let gitignoreEntries: [String]
     let supplementaryDoctorChecks: [any DoctorCheck]
 
     init(
         identifier: String,
         components: [ComponentDefinition] = [],
         templates: [TemplateContribution] = [],
-        gitignoreEntries: [String] = [],
         supplementaryDoctorChecks: [any DoctorCheck] = []
     ) {
         self.identifier = identifier
         self.components = components
         self.templates = templates
-        self.gitignoreEntries = gitignoreEntries
         self.supplementaryDoctorChecks = supplementaryDoctorChecks
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,7 +234,6 @@ protocol TechPack: Sendable {
     var description: String { get }
     var components: [ComponentDefinition] { get }
     var templates: [TemplateContribution] { get }
-    var gitignoreEntries: [String] { get }
     var supplementaryDoctorChecks: [any DoctorCheck] { get }
     func templateValues(context: ProjectConfigContext) -> [String: String]
     func declaredPrompts(context: ProjectConfigContext) -> [ExternalPromptDefinition]
@@ -245,7 +244,6 @@ protocol TechPack: Sendable {
 Packs provide:
 - **Components**: installable units (MCP servers, skills, etc.)
 - **Templates**: sections to inject into `CLAUDE.local.md`
-- **Gitignore entries**: patterns to add to the global gitignore
 - **Supplementary doctor checks**: pack-level diagnostics not derivable from components
 - **Template values**: resolved via prompts or scripts during sync
 - **Declared prompts**: prompt definitions for cross-pack deduplication (without executing them)

--- a/docs/techpack-schema.md
+++ b/docs/techpack-schema.md
@@ -19,7 +19,6 @@ Complete field-by-field reference for `techpack.yaml`. For a tutorial-style intr
 | `prompts` | `[Prompt]` | No | Interactive prompts for `mcs sync` |
 | `configureProject` | `ConfigureProject` | No | Script to run after project configuration |
 | `supplementaryDoctorChecks` | `[DoctorCheck]` | No | Pack-level health checks |
-| `gitignoreEntries` | `[String]` | No | Legacy gitignore entries (prefer `gitignore:` component) |
 
 ## Components
 


### PR DESCRIPTION
## Summary
- Remove the legacy top-level `gitignoreEntries` field from `TechPack` protocol, `ExternalPackManifest`, adapter, registry, and all install/doctor paths
- The modern `gitignore:` component shorthand (via `ExternalInstallAction.gitignoreEntries(entries:)`) remains as the sole mechanism
- Follows the same removal pattern as `hookContributions` (PR #156)
- All three tech packs (`mcs-core-pack`, `mcs-ios-pack`, `mcs-continuous-learning`) already use the modern component shorthand — no pack changes needed

## Test plan
- [x] `swift build` succeeds
- [x] All 637 tests pass (4 legacy tests removed)
- [x] Component-level `gitignore:` shorthand tests retained and passing
- [x] Docs updated (`techpack-schema.md`, `architecture.md`)

Closes #157