### PR TITLE
[#177] Warn when doctor --pack specifies unregistered packs

### DIFF
--- a/Sources/mcs/Doctor/DoctorRunner.swift
+++ b/Sources/mcs/Doctor/DoctorRunner.swift
@@ -109,6 +109,16 @@ struct DoctorRunner {
         var allPackIDs = Set<String>()
         let availablePacks = registry.availablePacks
 
+        // Warn about unregistered pack IDs from --pack filter
+        if packFilter != nil {
+            let availableIDs = Set(availablePacks.map(\.identifier))
+            for scope in scopes {
+                for id in scope.packIDs.sorted() where !availableIDs.contains(id) {
+                    output.warn("Pack \"\(id)\" is not registered \u{2014} no checks will be run for it")
+                }
+            }
+        }
+
         // Layer 1+2: Derived + supplementary checks from installed components (per scope)
         for scope in scopes {
             allPackIDs.formUnion(scope.packIDs)


### PR DESCRIPTION
## Summary

`mcs doctor --pack nonexistent` silently produces zero checks and a green summary with no indication that the pack name is invalid. This adds a warning for each unregistered pack ID, matching the existing pattern in `SyncCommand`.

Closes #177

## Changes

- Add validation in `DoctorRunner.run()` after resolving `availablePacks` and before check collection
- For each `--pack` ID not found in the registry, emit `output.warn("Pack \"<id>\" is not registered — no checks will be run for it")`
- Guarded by `packFilter != nil` so auto-detected scopes are unaffected
- Iterates sorted IDs for deterministic output order

## Test plan

- [ ] `swift test` passes locally
- [ ] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)
  - `mcs doctor --pack nonexistent` shows the warning
  - `mcs doctor --pack <valid>,nonexistent` warns about invalid, runs checks for valid
  - `mcs doctor --pack nonexistent --global` shows the warning
  - `mcs doctor` (no --pack) runs normally without warnings