### PR TITLE
Bump version to 2026.3.4

### DIFF
--- a/Sources/mcs/CLI.swift
+++ b/Sources/mcs/CLI.swift
@@ -3,7 +3,7 @@ import ArgumentParser
 /// Single source of truth for the CLI version.
 /// Used in markers, sidecar files, and `--version` output.
 enum MCSVersion {
-    static let current = "2026.3.2"
+    static let current = "2026.3.4"
 }
 
 @main


### PR DESCRIPTION
## Summary
- Bump `MCSVersion.current` from `2026.3.2` to `2026.3.4` for today's release

## Changes since 2026.3.2
- [#177] Warn when doctor --pack specifies unregistered packs
- [#176] Pass projectRoot into supplementaryDoctorChecks
- [#172] Remove pre-read fileExists check in Settings.load (TOCTOU)
- [#170] Rename ExternalPromptDefinition to PromptDefinition
- Add SwiftFormat and SwiftLint with CI enforcement
- [#157] Remove legacy top-level gitignoreEntries from manifest
- [#114] Remove default registry parameter from DoctorRunner.init
- docs: add subagent support to README
- [#109] Extract PackCommandContext to DRY PackCommand subcommands
- [#99] Add integration tests for PackFetcher fetch/update/currentCommitSHA