### PR TITLE
Fix Quick Start anchor links in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Documentation for [Managed Claude Stack (mcs)](../README.md) — a configuration
 
 New to mcs? Start here:
 
-1. [Install and Quick Start](../README.md#quick-start) — Get your first pack running in under 2 minutes
+1. [Install and Quick Start](../README.md#-quick-start) — Get your first pack running in under 2 minutes
 2. [CLI Reference](cli.md) — Complete command reference (`sync`, `pack`, `doctor`, `export`, `cleanup`)
 3. [Troubleshooting](troubleshooting.md) — Common issues and fixes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Complete command reference for `mcs`. For a quick introduction, see the [README](../README.md#quick-start).
+Complete command reference for `mcs`. For a quick introduction, see the [README](../README.md#-quick-start).
 
 ## `mcs sync`
 


### PR DESCRIPTION
## Context

The previous PR (#222) included a Copilot suggestion that changed `#-quick-start` to `#quick-start`. However, GitHub's anchor generation for emoji headings (`## 🚀 Quick Start`) produces `#-quick-start` with a leading dash — the original links were correct.

## Changes

- Restore `#-quick-start` anchor in `docs/README.md` and `docs/cli.md`

## Test Plan

- [x] Verified anchor resolves correctly on GitHub