### PR TITLE
[#236] Extract shared artifact-removal helpers

### DIFF
--- a/Sources/mcs/Install/Configurator.swift
+++ b/Sources/mcs/Install/Configurator.swift
@@ -759,6 +759,7 @@ struct Configurator {
                 if removeGitignoreArtifact(entry, gitignoreManager: gitignoreManager) {
                     output.dimmed("  Removed stale gitignore entry: \(entry)")
                 } else {
+                    // Helper already warned — re-add for retry on next sync
                     currentArtifacts.gitignoreEntries.append(entry)
                 }
             }
@@ -861,7 +862,7 @@ struct Configurator {
     private enum RefCountedRemovalResult {
         /// Resource was successfully uninstalled.
         case removed
-        /// Resource is still needed by another scope — safe to clear from this pack's record.
+        /// Resource is still needed by another scope; it was not uninstalled.
         case stillNeeded
         /// Removal was attempted but failed.
         case failed
@@ -885,7 +886,7 @@ struct Configurator {
     /// Remove a brew package with reference counting.
     ///
     /// Logs the "Keeping" message when the package is still needed by another scope.
-    /// Callers handle success/failure logging with their own context.
+    /// Callers provide their own success/failure context messages.
     private func removeBrewArtifact(
         _ package: String,
         exec: ComponentExecutor,
@@ -910,7 +911,7 @@ struct Configurator {
     /// Remove a plugin with reference counting.
     ///
     /// Logs the "Keeping" message when the plugin is still needed by another scope.
-    /// Callers handle success/failure logging with their own context.
+    /// Callers provide their own success/failure context messages.
     private func removePluginArtifact(
         _ name: String,
         exec: ComponentExecutor,


### PR DESCRIPTION
## Summary

Extracts per-artifact-type removal helpers from `Configurator.swift` to reduce duplication across `unconfigurePack()`, `removeNewlyExcludedComponentArtifacts()`, and `reconcileStaleArtifacts()`. Pure internal refactor — no behavioral changes.

Closes #236

## Changes

- Add `RefCountedRemovalResult` enum (`.removed`, `.stillNeeded`, `.failed`) for 3-way brew/plugin removal semantics
- Add 5 private helpers: `removeMCPServerArtifact`, `removeFileArtifactItem`, `removeBrewArtifact`, `removePluginArtifact`, `removeGitignoreArtifact`
- Refactor all 3 artifact-removal methods to delegate to shared helpers, eliminating ~70 lines of duplicated ref-counting, do/catch, and removal logic

## Test plan

- [x] `swift test` passes locally (4 unrelated `PackFetcherTests` failures from 1Password SSH agent)
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)

<details>
<summary>Checklist for engine changes</summary>

Only check items that apply to this PR. Delete irrelevant ones.

- N/A — pure refactor, no new paths, state changes, or behavior changes

</details>