### PR TITLE
Bump version to 2026.3.6

### DIFF
--- a/Sources/mcs/CLI.swift
+++ b/Sources/mcs/CLI.swift
@@ -3,7 +3,7 @@ import ArgumentParser
 /// Single source of truth for the CLI version.
 /// Used in markers, sidecar files, and `--version` output.
 enum MCSVersion {
-    static let current = "2026.3.5"
+    static let current = "2026.3.6"
 }
 
 @main


### PR DESCRIPTION
## Summary
- Bump `MCSVersion.current` from `2026.3.5` to `2026.3.6`

## Test plan
- [x] `swift build` passes
- [x] `swift test` passes (pre-existing 1Password SSH flake unrelated)
- [x] `swiftformat` and `swiftlint` clean