### PR TITLE
Fix interactive menu scrolling with long descriptions

### DIFF
--- a/Sources/mcs/Core/CLIOutput.swift
+++ b/Sources/mcs/Core/CLIOutput.swift
@@ -92,7 +92,7 @@ struct CLIOutput: Sendable {
     /// Counts visual terminal rows for a rendered output string,
     /// accounting for lines that wrap past `columns`.
     private func visualRowCount(of output: String, columns: Int) -> Int {
-        guard columns > 0 else { return output.filter { $0 == "\n" }.count }
+        guard columns > 0 else { return output.count(where: { $0 == "\n" }) }
 
         var lines = output.split(separator: "\n", omittingEmptySubsequences: false)
         if lines.last?.isEmpty == true { lines.removeLast() }


### PR DESCRIPTION
## Context
When running `mcs sync` with packs that have long component descriptions (e.g. `tr-ai-kit`), navigating with arrow keys caused the terminal to scroll instead of refreshing in place. YAML `>` folding joins multi-line descriptions into single long strings (~290 chars), which wrap to multiple terminal rows. The rerender logic only counted logical lines, not visual rows, so the cursor-up ANSI escape undershot and old content accumulated on screen.

## Changes
- Add `wordWrap` to break long descriptions at word boundaries with proper indentation on continuation lines
- Add `visualRowCount` to compute actual terminal rows (stripping ANSI codes, dividing by terminal width) instead of counting logical `\n` lines
- Extract `buildInteractiveListString` / `buildSingleSelectListString` so rendering and row counting share a single source of truth
- Add `terminalColumns` computed property via `ioctl(TIOCGWINSZ)` with fallback to 80

## Testing Steps
- [ ] Register a pack with long descriptions: `mcs pack add ~/Developer/tr-ai-kit`
- [ ] Run `mcs sync` in a project and navigate up/down — menu should refresh in place
- [ ] Test with a narrow terminal window (e.g. 60 columns) to verify wrapping is handled
- [ ] `swift test` — all 715 tests pass