### PR TITLE
[#121] Add sandbox tests for core doctor checks

### DIFF
--- a/Tests/MCSTests/CoreDoctorCheckSandboxTests.swift
+++ b/Tests/MCSTests/CoreDoctorCheckSandboxTests.swift
@@ -501,7 +501,8 @@ struct DerivedDoctorCheckSandboxTests {
             #expect(fileCheck.path.path.hasPrefix(projectRoot.path))
             // Fallback path should be under the sandbox home
             #expect(fileCheck.fallbackPath != nil)
-            #expect(try #require(fileCheck.fallbackPath?.path.hasPrefix(home.path)))
+            let fallback = try #require(fileCheck.fallbackPath)
+            #expect(fallback.path.hasPrefix(home.path))
         } else {
             Issue.record("Expected FileExistsCheck, got \(type(of: check!))")
         }

--- a/Tests/MCSTests/PackFetcherTests.swift
+++ b/Tests/MCSTests/PackFetcherTests.swift
@@ -12,7 +12,6 @@ private func makeFetcher() -> PackFetcher {
     )
 }
 
-@Suite("PackFetcher ref validation")
 struct PackFetcherRefValidationTests {
     // MARK: - Valid refs
 
@@ -98,7 +97,6 @@ struct PackFetcherRefValidationTests {
     }
 }
 
-@Suite("PackFetcher identifier validation")
 struct PackFetcherIdentifierValidationTests {
     // MARK: - Valid identifiers
 
@@ -150,7 +148,6 @@ struct PackFetcherIdentifierValidationTests {
 
 // MARK: - Integration Tests (git operations)
 
-@Suite("PackFetcher operations")
 struct PackFetcherOperationTests {
     private struct TestSetupError: Error {
         let message: String
@@ -215,6 +212,8 @@ struct PackFetcherOperationTests {
                 context: "git config user.email")
         try git(shell, ["-C", workDir.path, "config", "user.name", "MCS Test"],
                 context: "git config user.name")
+        try git(shell, ["-C", workDir.path, "config", "commit.gpgsign", "false"],
+                context: "git config commit.gpgsign")
 
         let readme = workDir.appendingPathComponent("README.md")
         try "initial".write(to: readme, atomically: true, encoding: .utf8)

--- a/Tests/MCSTests/PackUpdaterTests.swift
+++ b/Tests/MCSTests/PackUpdaterTests.swift
@@ -60,6 +60,8 @@ struct PackUpdaterTests {
                 context: "git config email")
         try git(shell, ["-C", workDir.path, "config", "user.name", "MCS Test"],
                 context: "git config name")
+        try git(shell, ["-C", workDir.path, "config", "commit.gpgsign", "false"],
+                context: "git config commit.gpgsign")
 
         let manifest = """
         schemaVersion: 1


### PR DESCRIPTION
## Summary

Add sandbox tests for all core doctor check structs that were made injectable in PR #256. Each test creates a temp directory, constructs `Environment(home: tmpDir)`, and verifies check behavior against controlled file fixtures — no real `~/` paths are touched.

Stacked on #256 (PR 1 of the #121 series).

## Changes

- Add `CoreDoctorCheckSandboxTests.swift` with 23 tests across 5 suites:
  - `MCPServerCheckSandboxTests` (5 tests): global/project-scoped servers, missing server, missing file, invalid JSON
  - `PluginCheckSandboxTests` (3 tests): enabled/not-enabled plugin, missing settings
  - `HookCheckSandboxTests` (6 tests): present+executable, missing, optional skip, not-executable, fix makes executable, fix when missing
  - `ProjectIndexCheckSandboxTests` (5 tests): all paths valid, stale paths, empty index, fix prunes stale, global sentinel
  - `DerivedDoctorCheckSandboxTests` (4 tests): copyPackFile global URL, copyPackFile with project root + fallback, mcpServer uses env, allDoctorChecks forwards env

## Test plan

- [x] `swift test` passes locally (758 tests, only pre-existing 1Password SSH agent failures in PackFetcher/PackUpdater)
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)