### PR TITLE
[#121] Add DoctorRunner integration test harness

### DIFF
--- a/Tests/MCSTests/DoctorRunnerIntegrationTests.swift
+++ b/Tests/MCSTests/DoctorRunnerIntegrationTests.swift
@@ -4,33 +4,6 @@ import Testing
 
 // MARK: - Helpers
 
-private func makeSandboxProject(label: String = "runner") throws -> (home: URL, project: URL) {
-    let home = FileManager.default.temporaryDirectory
-        .appendingPathComponent("mcs-\(label)-\(UUID().uuidString)")
-    try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
-    // Create ~/.claude/ and ~/.mcs/ subdirectories
-    try FileManager.default.createDirectory(
-        at: home.appendingPathComponent(".claude"),
-        withIntermediateDirectories: true
-    )
-    try FileManager.default.createDirectory(
-        at: home.appendingPathComponent(".mcs"),
-        withIntermediateDirectories: true
-    )
-    // Create a project dir with .git/ marker
-    let project = home.appendingPathComponent("test-project")
-    try FileManager.default.createDirectory(
-        at: project.appendingPathComponent(".git"),
-        withIntermediateDirectories: true
-    )
-    // Create .claude/ inside the project
-    try FileManager.default.createDirectory(
-        at: project.appendingPathComponent(".claude"),
-        withIntermediateDirectories: true
-    )
-    return (home, project)
-}
-
 private func makeRunner(
     home: URL,
     projectRoot: URL? = nil,

--- a/Tests/MCSTests/TestHelpers.swift
+++ b/Tests/MCSTests/TestHelpers.swift
@@ -140,6 +140,22 @@ func makeGlobalTmpDir(label: String = "global") throws -> URL {
     return dir
 }
 
+/// Create a temp directory pre-configured as a project sandbox:
+/// home with `.claude/` + `.mcs/`, plus a nested project with `.git/` + `.claude/`.
+func makeSandboxProject(label: String = "project") throws -> (home: URL, project: URL) {
+    let home = try makeGlobalTmpDir(label: label)
+    let project = home.appendingPathComponent("test-project")
+    try FileManager.default.createDirectory(
+        at: project.appendingPathComponent(".git"),
+        withIntermediateDirectories: true
+    )
+    try FileManager.default.createDirectory(
+        at: project.appendingPathComponent(Constants.FileNames.claudeDirectory),
+        withIntermediateDirectories: true
+    )
+    return (home, project)
+}
+
 /// Create a `Configurator` configured for global-scope sync.
 func makeGlobalConfigurator(
     home: URL,


### PR DESCRIPTION
## Summary

Add a test harness that exercises `DoctorRunner.run()` end-to-end in a fully sandboxed environment. This verifies the runner correctly resolves scopes, loads project state, filters by pack, and handles excluded components — all without touching real `~/` paths.

Stacked on #257 (PR 2 of the #121 series).

## Changes

- Add `DoctorRunnerIntegrationTests.swift` with 6 tests:
  - Empty registry completes without error
  - `globalOnly` flag restricts to global scope
  - `packFilter` restricts to specified packs
  - Missing artifacts from state file are detected
  - Excluded components are skipped
  - Project packs are resolved from `.mcs-project` state

## Test plan

- [x] `swift test` passes locally (764 tests, 0 failures)
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)