### PR TITLE
Bump version to 2026.3.22

### DIFF
--- a/Sources/mcs/CLI.swift
+++ b/Sources/mcs/CLI.swift
@@ -3,7 +3,7 @@ import ArgumentParser
 /// Single source of truth for the CLI version.
 /// Used in markers, sidecar files, and `--version` output.
 enum MCSVersion {
-    static let current = "2026.3.17"
+    static let current = "2026.3.22"
 }
 
 @main


### PR DESCRIPTION
## Summary
- Version bump for release `2026.3.22`

### Changes since `2026.3.17` (10 commits)
- [#266] Consolidate hook metadata into HookRegistration struct (#268)
- [#224] Add timeout, async, and statusMessage to HookEntry (#267)
- [#217] Defer component supplementary check construction (#265)
- Add macOS version matrix to PR checks CI (#264)
- [#121] Add end-to-end lifecycle integration tests (#259)
- [#121] Add DoctorRunner integration test harness (#258)
- [#121] Add sandbox tests for core doctor checks (#261)
- [#121] Make DoctorRunner and checks accept injectable Environment (#256)
- [#119] Add settings drift detection to doctor (#255)
- [#252] Fix pack update inconsistent state on trust denial (#253)

## Release checklist
- [ ] PR merged to main
- [ ] Tag `2026.3.22` created on merge commit
- [ ] Tag pushed → release workflow runs automatically