### PR TITLE
Update actions/cache to v5 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             .build/checkouts
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: |
             .build/checkouts
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: |
             .build/checkouts


### PR DESCRIPTION
## Summary
- Bump `actions/cache` from v4 to v5 and `actions/cache/restore` from v4 to v5 in `release.yml`
- Resolves Node.js 20 deprecation warnings (`pr-checks.yml` was already on v5)