### PR TITLE
Bump version to 2026.3.23

### DIFF
--- a/Sources/mcs/CLI.swift
+++ b/Sources/mcs/CLI.swift
@@ -3,7 +3,7 @@ import ArgumentParser
 /// Single source of truth for the CLI version.
 /// Used in markers, sidecar files, and `--version` output.
 enum MCSVersion {
-    static let current = "2026.3.22"
+    static let current = "2026.3.23"
 }
 
 @main


### PR DESCRIPTION
## Summary

Version bump for release 2026.3.23.

## Changes

- Bump `MCSVersion.current` from `2026.3.22` to `2026.3.23`

## Test plan

- [x] `swift build` passes