### PR TITLE
Replace sponsor badge with DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![macOS](https://img.shields.io/badge/macOS-13+-000000.svg?logo=apple&logoColor=white)](https://www.apple.com/macos/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Homebrew](https://img.shields.io/badge/Homebrew-tap-FBB040.svg?logo=homebrew&logoColor=white)](https://github.com/bguidolim/homebrew-tap)
-[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-❤️-ea4aaa.svg?logo=github)](https://github.com/sponsors/bguidolim)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/bguidolim/mcs)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Remove GitHub Sponsors badge from README
- Add "Ask DeepWiki" badge linking to https://deepwiki.com/bguidolim/mcs
- Uses DeepWiki's official badge SVG (`https://deepwiki.com/badge.svg`)

## Test plan
- [ ] Verify badge renders correctly on the PR preview
- [ ] Confirm badge links to the correct DeepWiki page