### PR TITLE
Add interactive arrow-key Yes/No prompt

### DIFF
--- a/Sources/mcs/Core/CLIOutput.swift
+++ b/Sources/mcs/Core/CLIOutput.swift
@@ -513,11 +513,6 @@ struct CLIOutput {
     ) -> String {
         var output = ""
 
-        output += "\n"
-        output += "  Use \(bold)\u{2191}\u{2193}\(reset) to move, "
-        output += "\(bold)space\(reset) to toggle, "
-        output += "\(bold)enter\(reset) to confirm\n"
-
         var flatIndex = 0
         for group in groups where !group.items.isEmpty {
             output += "\n"
@@ -545,6 +540,7 @@ struct CLIOutput {
         }
 
         output += "\n"
+        output += "  \(dim)\u{2191}/\u{2193} Move \u{00B7} Space Toggle \u{00B7} Enter Confirm\(reset)\n"
         return output
     }
 


### PR DESCRIPTION
## Summary

Upgrades `askYesNo` from plain text input (`type y or n`) to an interactive horizontal arrow-key selector, consistent with the existing `singleSelect` and `multiSelect` UX. Also refactors shared raw terminal infrastructure to eliminate duplication across all three interactive prompts, and standardizes hint line placement and style.

## Changes

- Add `interactiveYesNo` with horizontal `› Yes   No` layout using left/right arrows, y/n shortcuts, Enter/Space to confirm
- Extract `withRawTerminal(_:)` helper replacing 3 duplicated raw terminal setup/teardown blocks
- Extract `readCSIArrowKey()` helper replacing 3 duplicated CSI escape sequence parsers
- Add stored `isInteractiveTerminal` property replacing 3 identical TTY checks
- Move multi-select keyboard hint from top (inline prose) to bottom (dim with `·` separators), matching single-select and yes/no style
- Non-TTY fallback preserves existing `[Y/n]` text input behavior — all 10 call sites unchanged

## Test plan

- [x] `swift test` passes locally (866 tests)
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs cleanup`, `mcs pack remove`, `mcs doctor --fix`)