### PR TITLE
Revert interactive hook directive, show pack names

### DIFF
--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -308,36 +308,28 @@ struct UpdateChecker {
     }
 
     /// Build a context string for Claude from check results.
-    /// Uses strong directive language to ensure Claude stops and asks the user before proceeding.
+    /// Uses strong directive language to ensure Claude relays the notification visibly.
     private static func buildContextString(_ result: CheckResult) -> String {
         var lines: [String] = []
         lines.append(
-            "STOP. Before doing ANY work, you MUST relay the following update notifications to the user"
-                + " and ask if they want to skip the updates and proceed with their task."
+            "STOP. Before doing ANY work, you MUST relay the following update notifications to the user."
                 + " This is non-negotiable even if the user's message is a task request."
         )
         lines.append("")
         if let cli = result.cliUpdate {
             lines.append(
                 "- New mcs version \(cli.latestVersion) is available (installed: \(cli.currentVersion))."
-                    + " Update command: brew upgrade \(Constants.MCSRepo.brewFormula)"
+                    + " The user should run: brew upgrade \(Constants.MCSRepo.brewFormula)"
             )
         }
         if !result.packUpdates.isEmpty {
+            let names = result.packUpdates.map(\.displayName).joined(separator: ", ")
             let noun = result.packUpdates.count == 1 ? "tech pack has" : "tech packs have"
             lines.append(
-                "- \(result.packUpdates.count) \(noun) updates available."
-                    + " Update command: mcs pack update"
+                "- \(result.packUpdates.count) \(noun) updates available: \(names)."
+                    + " The user should run: mcs pack update"
             )
         }
-        lines.append("")
-        lines.append(
-            "If the user does NOT want to skip:"
-                + " run `brew upgrade \(Constants.MCSRepo.brewFormula)` for CLI updates."
-                + " For pack updates, tell the user to run `mcs pack update` in a separate terminal"
-                + " (pack updates may prompt for interactive trust approval and cannot run inside Claude Code)."
-                + " If the user wants to skip, proceed immediately with their original request."
-        )
         return lines.joined(separator: "\n")
     }
 


### PR DESCRIPTION
## Summary

- Revert the "ask to skip" interactive behavior from #322 — `additionalContext` is injected as context alongside the user's message, so Claude cannot truly stop and wait for input
- List pack display names in the update notification instead of just the count (e.g., `2 tech packs have updates available: iOS Pack, Swift Lint Pack`)

## Test plan

- [ ] `swift build` succeeds
- [ ] `swift test` passes
- [ ] Run `mcs check-updates --hook` with stale packs and verify pack names appear in the `additionalContext` JSON