### PR TITLE
fix: allow identical copyPackFile source across components

### DIFF
--- a/Sources/mcs/ExternalPack/ExternalPackManifest.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackManifest.swift
@@ -89,30 +89,43 @@ extension ExternalPackManifest {
                 }
             }
 
-            // Validate no duplicate copyPackFile destinations within the pack
+            // Validate no conflicting copyPackFile destinations within the pack.
+            // Multiple components may legitimately share a (destination, fileType) when
+            // they copy the same source — e.g., one hook script registered against two
+            // hook events via two components. A real conflict is same destination with
+            // different sources.
             struct DestKey: Hashable {
                 let destination: String
                 let fileType: String
             }
-            var seenDestinations: [DestKey: [String]] = [:]
+            struct DestEntry {
+                let componentID: String
+                let source: String
+            }
+            var seenDestinations: [DestKey: [DestEntry]] = [:]
             for component in components {
                 if case let .copyPackFile(config) = component.installAction {
                     let key = DestKey(
                         destination: config.destination,
-                        fileType: config.fileType?.rawValue ?? "generic"
+                        fileType: config.fileType?.rawValue ?? ExternalCopyFileType.generic.rawValue
                     )
-                    seenDestinations[key, default: []].append(component.id)
+                    seenDestinations[key, default: []].append(
+                        DestEntry(componentID: component.id, source: config.source)
+                    )
                 }
             }
-            for key in seenDestinations.keys.sorted(by: { ($0.destination, $0.fileType) < ($1.destination, $1.fileType) }) {
-                let componentIDs = seenDestinations[key]!
-                if componentIDs.count > 1 {
-                    throw ManifestError.duplicateDestination(
-                        destination: key.destination,
-                        fileType: key.fileType,
-                        componentIDs: componentIDs
-                    )
-                }
+            let sortedDestinations = seenDestinations.sorted { lhs, rhs in
+                (lhs.key.destination, lhs.key.fileType) < (rhs.key.destination, rhs.key.fileType)
+            }
+            for (key, entries) in sortedDestinations {
+                guard entries.count > 1 else { continue }
+                // Identity case: every entry copies the same source file — benign.
+                if entries.dropFirst().allSatisfy({ $0.source == entries[0].source }) { continue }
+                throw ManifestError.duplicateDestination(
+                    destination: key.destination,
+                    fileType: key.fileType,
+                    componentIDs: entries.map(\.componentID)
+                )
             }
         }
 

--- a/Tests/MCSTests/ExternalPackManifestTests.swift
+++ b/Tests/MCSTests/ExternalPackManifestTests.swift
@@ -491,6 +491,39 @@ struct ExternalPackManifestTests {
         }
     }
 
+    @Test("Validation allows same source/destination across multiple hook events")
+    func allowSameSourceDestinationAcrossHookEvents() throws {
+        let yaml = """
+        schemaVersion: 1
+        identifier: my-pack
+        displayName: Test
+        description: Test
+        version: "1.0.0"
+        components:
+          - id: my-pack.sync-on-start
+            description: Sync on session start
+            hookEvent: SessionStart
+            hook:
+              source: hooks/sync.sh
+              destination: sync.sh
+          - id: my-pack.sync-on-prompt
+            description: Sync on user prompt
+            hookEvent: UserPromptSubmit
+            hook:
+              source: hooks/sync.sh
+              destination: sync.sh
+        """
+
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let file = tmpDir.appendingPathComponent("techpack.yaml")
+        try yaml.write(to: file, atomically: true, encoding: .utf8)
+
+        let manifest = try ExternalPackManifest.load(from: file)
+        try manifest.validate()
+    }
+
     @Test("Validation allows same destination with different file types")
     func allowSameDestinationDifferentFileTypes() throws {
         let yaml = """


### PR DESCRIPTION
## Summary

PR #320 introduced intra-pack duplicate-destination validation that incorrectly rejected a legitimate pattern: one physical hook script registered against multiple hook events. Because `hookEvent` is singular per component, authors must declare N components — all copying the same source to the same destination — which is an identity, not a collision. This PR tightens the validator so it only throws when sources actually differ.

## Changes

- `ExternalPackManifest.validate()` now tracks `(componentID, source)` per destination group. For groups with more than one entry, an `allSatisfy` check collapses the identity case (every entry copies the same source → benign, skipped). Real conflicts (distinct sources for the same destination) still throw `ManifestError.duplicateDestination`.
- Replaced the `"generic"` string fallback with `ExternalCopyFileType.generic.rawValue` to drop the stringly-typed literal.
- Removed a force-unwrap on the dictionary lookup by iterating sorted key-value pairs directly.
- Added `allowSameSourceDestinationAcrossHookEvents` test covering two hook components sharing both `source` and `destination`. Existing `rejectDuplicate*` tests still cover the real-collision branch.

## Context

Real-world hit: the `mcs-memory` pack declares `hook-sync-memories` (`SessionStart`) and `hook-reindex-memories` (`UserPromptSubmit`), both copying `hooks/sync-memories.sh` → `sync-memories.sh`. After PR #320, `mcs sync --global` warned:

```
[WARN] Skipping pack 'memory': Invalid manifest for pack 'memory':
  Duplicate copyPackFile destination 'sync-memories.sh' (fileType: hook)
  in components: memory.hook-sync-memories, memory.hook-reindex-memories
```

This is the same file being registered against two hook events, not two files fighting for one destination. The validator should only catch the latter.

A more architecturally elegant alternative — letting `hookEvent` accept an array so one component registers for multiple events — was considered but deferred. That change ripples through ~13 files (`HookRegistration.event`, encoder/decoder, sync strategies, `PackArtifactRecord.hookCommands`, doctor checks, export/discovery, collision resolver) and deserves its own PR.

`ExternalCopyPackFileConfig` has exactly three fields (`source`, `destination`, `fileType?`) with no hidden mode/permissions/ownership, so `source` equality is a complete identity check.

## Test plan

- [x] `swift test --filter MCSTests.ExternalPackManifestTests` — 92/92 pass
- [x] `swift test` — 978/978 pass
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [x] End-to-end: `swift run mcs pack validate ~/Developer/mcs-memory` → `[OK] memory — all checks passed`
- [x] Existing conflict tests (`rejectDuplicateCopyPackFileDestinations`, `rejectDuplicateGenericFileTypeDestinations`) still reject the real-collision branch

<details>
<summary>Checklist for engine changes</summary>

- [x] Integration tests updated for new features — added unit test to `ExternalPackManifestTests`; integration lifecycle is unchanged (validator is the only touched path)
- [x] Docs updated if behavior changed — N/A, this restores behavior PR #320 broke

</details>