### PR TITLE
feat: add shellInteractive flag for PTY-based shell commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ mcs config set <key> <value>     # Set a configuration value (true/false)
 - `DependencyResolver.swift` — topological sort of component dependencies with cycle detection
 
 ### External Pack System (`Sources/mcs/ExternalPack/`)
-- `ExternalPackManifest.swift` — YAML `techpack.yaml` schema (Codable models for components, templates, hooks, doctor checks, configure scripts). Supports **shorthand syntax** (`brew:`, `mcp:`, `plugin:`, `hook:`, `command:`, `skill:`, `agent:`, `settingsFile:`, `gitignore:`, `shell:`) that infers `type` + `installAction` from a single key
+- `ExternalPackManifest.swift` — YAML `techpack.yaml` schema (Codable models for components, templates, hooks, doctor checks, configure scripts). Supports **shorthand syntax** (`brew:`, `mcp:`, `plugin:`, `hook:`, `command:`, `skill:`, `agent:`, `settingsFile:`, `gitignore:`, `shell:`) that infers `type` + `installAction` from a single key. `shellInteractive: true` alongside `shell:` allocates a PTY for commands needing terminal access (e.g. `sudo`)
 - `ExternalPackAdapter.swift` — bridges `ExternalPackManifest` to the `TechPack` protocol
 - `ExternalPackLoader.swift` — discovers and loads packs from `~/.mcs/packs/` (git) or absolute paths (local)
 - `PackFetcher.swift` — Git clone/pull for pack repositories

--- a/Sources/mcs/Core/ShellRunner.swift
+++ b/Sources/mcs/Core/ShellRunner.swift
@@ -193,6 +193,11 @@ struct ShellRunner: ShellRunning {
         let argv: [UnsafeMutablePointer<CChar>?] = ([executable] + arguments).map { strdup($0) } + [nil]
         defer { argv.compactMap(\.self).forEach { free($0) } }
 
+        // Pre-convert workingDirectory to a C string before fork so the child
+        // doesn't need to invoke Swift's String-to-CString bridge (not fork-safe).
+        let cwdCStr = workingDirectory.map { strdup($0) }
+        defer { cwdCStr.map { free($0) } }
+
         // Save the terminal's current attributes so we can restore them after.
         var originalTermios = termios()
         let hasTerminal = tcgetattr(STDIN_FILENO, &originalTermios) == 0
@@ -211,9 +216,8 @@ struct ShellRunner: ShellRunning {
             // After fork, only async-signal-safe functions are safe. Avoid Swift
             // runtime calls (String interpolation, ARC) — they can deadlock on
             // locks held by other threads in the parent at fork time.
-            if let cwd = workingDirectory {
+            if let cwd = cwdCStr {
                 if chdir(cwd) != 0 {
-                    // Use only C functions — no Swift String operations.
                     let err = strerror(errno)
                     _ = write(STDERR_FILENO, "chdir failed: ", 14)
                     if let err { _ = write(STDERR_FILENO, err, strlen(err)) }
@@ -282,8 +286,6 @@ struct ShellRunner: ShellRunning {
                 let n = read(ptyFD, &buf, buf.count)
                 if n <= 0 { break bridgeLoop } // Child closed the PTY
                 writeAll(fd: STDOUT_FILENO, buf: buf, count: n)
-            } else if fds[1].revents & Int16(POLLHUP) != 0 {
-                break bridgeLoop
             }
         }
 

--- a/Sources/mcs/Core/ShellRunner.swift
+++ b/Sources/mcs/Core/ShellRunner.swift
@@ -208,16 +208,25 @@ struct ShellRunner: ShellRunning {
 
         if pid == 0 {
             // ── Child process ──
+            // After fork, only async-signal-safe functions are safe. Avoid Swift
+            // runtime calls (String interpolation, ARC) — they can deadlock on
+            // locks held by other threads in the parent at fork time.
             if let cwd = workingDirectory {
                 if chdir(cwd) != 0 {
-                    let msg = "chdir failed: \(String(cString: strerror(errno)))\n"
-                    msg.withCString { _ = write(STDERR_FILENO, $0, strlen($0)) }
+                    // Use only C functions — no Swift String operations.
+                    let err = strerror(errno)
+                    _ = write(STDERR_FILENO, "chdir failed: ", 14)
+                    if let err { _ = write(STDERR_FILENO, err, strlen(err)) }
+                    _ = write(STDERR_FILENO, "\n", 1)
                     _exit(126)
                 }
             }
-            execve(executable, argv, envp)
-            let msg = "execve failed: \(String(cString: strerror(errno)))\n"
-            msg.withCString { _ = write(STDERR_FILENO, $0, strlen($0)) }
+            // Use argv[0] (already a C string from strdup) instead of the Swift String.
+            execve(argv[0], argv, envp)
+            let err = strerror(errno)
+            _ = write(STDERR_FILENO, "execve failed: ", 15)
+            if let err { _ = write(STDERR_FILENO, err, strlen(err)) }
+            _ = write(STDERR_FILENO, "\n", 1)
             _exit(127)
         }
 
@@ -235,49 +244,46 @@ struct ShellRunner: ShellRunning {
         // Ensure terminal is restored even if we exit early or the process is interrupted.
         defer {
             if hasTerminal {
-                if tcsetattr(STDIN_FILENO, TCSANOW, &originalTermios) != 0 {
-                    tcsetattr(STDIN_FILENO, TCSADRAIN, &originalTermios)
-                }
+                tcsetattr(STDIN_FILENO, TCSADRAIN, &originalTermios)
             }
             close(ptyFD)
         }
 
-        // Bridge I/O between the real terminal and the PTY.
-        // Uses select() to multiplex stdin → PTY and PTY → stdout.
-        let stdinFD = STDIN_FILENO
-        let stdoutFD = STDOUT_FILENO
+        // Bridge I/O between the real terminal and the PTY using poll().
+        var fds: [pollfd] = [
+            pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0),
+            pollfd(fd: ptyFD, events: Int16(POLLIN), revents: 0),
+        ]
         var buf = [UInt8](repeating: 0, count: 4096)
-        var stdinOpen = true
 
         bridgeLoop: while true {
-            var readSet = fd_set()
-            fdZero(&readSet)
-            if stdinOpen { fdSet(stdinFD, set: &readSet) }
-            fdSet(ptyFD, set: &readSet)
+            fds[0].revents = 0
+            fds[1].revents = 0
 
-            let maxFD = max(stdinOpen ? stdinFD : 0, ptyFD) + 1
-            let ready = select(maxFD, &readSet, nil, nil, nil)
+            let ready = poll(&fds, nfds_t(fds.count), -1)
             if ready < 0 {
                 if errno == EINTR { continue } // Retry on signal interruption
                 break
             }
-            if ready == 0 { continue }
 
             // Terminal → PTY (user typing, including password input)
-            if stdinOpen, fdIsSet(stdinFD, set: &readSet) {
-                let n = read(stdinFD, &buf, buf.count)
+            if fds[0].revents & Int16(POLLIN) != 0 {
+                let n = read(STDIN_FILENO, &buf, buf.count)
                 if n <= 0 {
-                    stdinOpen = false // stdin EOF — stop monitoring
+                    // stdin EOF — stop monitoring, let PTY drain remaining output
+                    fds[0].fd = -1
                 } else {
-                    writeAll(fd: ptyFD, buf: &buf, count: n)
+                    writeAll(fd: ptyFD, buf: buf, count: n)
                 }
             }
 
             // PTY → Terminal (command output, prompts, progress bars)
-            if fdIsSet(ptyFD, set: &readSet) {
+            if fds[1].revents & Int16(POLLIN | POLLHUP) != 0 {
                 let n = read(ptyFD, &buf, buf.count)
                 if n <= 0 { break bridgeLoop } // Child closed the PTY
-                writeAll(fd: stdoutFD, buf: &buf, count: n)
+                writeAll(fd: STDOUT_FILENO, buf: buf, count: n)
+            } else if fds[1].revents & Int16(POLLHUP) != 0 {
+                break bridgeLoop
             }
         }
 
@@ -298,7 +304,7 @@ struct ShellRunner: ShellRunning {
     }
 
     /// Write all bytes to a file descriptor, retrying on partial writes and EINTR.
-    private func writeAll(fd: Int32, buf: inout [UInt8], count: Int) {
+    private func writeAll(fd: Int32, buf: [UInt8], count: Int) {
         buf.withUnsafeBufferPointer { ptr in
             var offset = 0
             while offset < count {
@@ -309,35 +315,6 @@ struct ShellRunner: ShellRunning {
                 }
                 offset += n
             }
-        }
-    }
-
-    // MARK: - fd_set Helpers
-
-    // Swift doesn't expose FD_ZERO / FD_SET / FD_ISSET macros.
-
-    private func fdZero(_ set: inout fd_set) {
-        withUnsafeMutablePointer(to: &set) { ptr in
-            let rawPtr = UnsafeMutableRawPointer(ptr)
-            memset(rawPtr, 0, MemoryLayout<fd_set>.size)
-        }
-    }
-
-    private func fdSet(_ fd: Int32, set: inout fd_set) {
-        let intOffset = Int(fd) / (MemoryLayout<Int32>.size * 8)
-        let bitOffset = Int(fd) % (MemoryLayout<Int32>.size * 8)
-        withUnsafeMutablePointer(to: &set) { ptr in
-            let rawPtr = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: Int32.self)
-            rawPtr[intOffset] |= Int32(1 << bitOffset)
-        }
-    }
-
-    private func fdIsSet(_ fd: Int32, set: inout fd_set) -> Bool {
-        let intOffset = Int(fd) / (MemoryLayout<Int32>.size * 8)
-        let bitOffset = Int(fd) % (MemoryLayout<Int32>.size * 8)
-        return withUnsafeMutablePointer(to: &set) { ptr in
-            let rawPtr = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: Int32.self)
-            return rawPtr[intOffset] & Int32(1 << bitOffset) != 0
         }
     }
 }

--- a/Sources/mcs/Core/ShellRunner.swift
+++ b/Sources/mcs/Core/ShellRunner.swift
@@ -25,7 +25,8 @@ protocol ShellRunning: Sendable {
         _ executable: String,
         arguments: [String],
         workingDirectory: String?,
-        additionalEnvironment: [String: String]
+        additionalEnvironment: [String: String],
+        interactive: Bool
     ) -> ShellResult
 
     /// Run a shell command string via /bin/bash -c.
@@ -33,7 +34,8 @@ protocol ShellRunning: Sendable {
     func shell(
         _ command: String,
         workingDirectory: String?,
-        additionalEnvironment: [String: String]
+        additionalEnvironment: [String: String],
+        interactive: Bool
     ) -> ShellResult
 }
 
@@ -45,18 +47,26 @@ extension ShellRunning {
         _ executable: String,
         arguments: [String] = [],
         workingDirectory: String? = nil,
-        additionalEnvironment: [String: String] = [:]
+        additionalEnvironment: [String: String] = [:],
+        interactive: Bool = false
     ) -> ShellResult {
-        run(executable, arguments: arguments, workingDirectory: workingDirectory, additionalEnvironment: additionalEnvironment)
+        run(
+            executable, arguments: arguments, workingDirectory: workingDirectory,
+            additionalEnvironment: additionalEnvironment, interactive: interactive
+        )
     }
 
     @discardableResult
     func shell(
         _ command: String,
         workingDirectory: String? = nil,
-        additionalEnvironment: [String: String] = [:]
+        additionalEnvironment: [String: String] = [:],
+        interactive: Bool = false
     ) -> ShellResult {
-        shell(command, workingDirectory: workingDirectory, additionalEnvironment: additionalEnvironment)
+        shell(
+            command, workingDirectory: workingDirectory,
+            additionalEnvironment: additionalEnvironment, interactive: interactive
+        )
     }
 }
 
@@ -71,22 +81,35 @@ struct ShellRunner: ShellRunning {
     }
 
     /// Run an executable with arguments, capturing stdout and stderr.
+    ///
+    /// - Parameter interactive: When `true`, uses `forkpty()` to allocate a
+    ///   real pseudo-terminal so commands like `sudo` can prompt for passwords
+    ///   securely. Output goes directly to the terminal (not captured).
+    ///   Defaults to `false` (stdin `/dev/null`, stdout/stderr piped).
     @discardableResult
     func run(
         _ executable: String,
         arguments: [String],
         workingDirectory: String?,
-        additionalEnvironment: [String: String]
+        additionalEnvironment: [String: String],
+        interactive: Bool
     ) -> ShellResult {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = arguments
-
         var env = ProcessInfo.processInfo.environment
         env["PATH"] = environment.pathWithBrew
         for (key, value) in additionalEnvironment {
             env[key] = value
         }
+
+        if interactive {
+            return runInteractive(
+                executable: executable, arguments: arguments,
+                environment: env, workingDirectory: workingDirectory
+            )
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
         process.environment = env
 
         if let cwd = workingDirectory {
@@ -133,13 +156,159 @@ struct ShellRunner: ShellRunning {
     func shell(
         _ command: String,
         workingDirectory: String?,
-        additionalEnvironment: [String: String]
+        additionalEnvironment: [String: String],
+        interactive: Bool
     ) -> ShellResult {
         run(
             Constants.CLI.bash,
             arguments: ["-c", command],
             workingDirectory: workingDirectory,
-            additionalEnvironment: additionalEnvironment
+            additionalEnvironment: additionalEnvironment,
+            interactive: interactive
         )
+    }
+
+    /// Run a command with a real pseudo-terminal using `forkpty()`.
+    ///
+    /// `Foundation.Process` never allocates a PTY, so commands like `sudo`
+    /// that require `isatty() == true` fail with "unable to read password".
+    /// This method uses `forkpty()` to create a real PTY pair and then
+    /// bridges I/O between the parent terminal and the child's PTY so that
+    /// `sudo` can properly disable echo and read passwords securely.
+    private func runInteractive(
+        executable: String,
+        arguments: [String],
+        environment env: [String: String],
+        workingDirectory: String?
+    ) -> ShellResult {
+        // Prepare environment and argv as C strings for execve().
+        let envp: [UnsafeMutablePointer<CChar>?] = env.map { key, value in
+            strdup("\(key)=\(value)")
+        } + [nil]
+        defer { envp.compactMap(\.self).forEach { free($0) } }
+
+        let argv: [UnsafeMutablePointer<CChar>?] = ([executable] + arguments).map { strdup($0) } + [nil]
+        defer { argv.compactMap(\.self).forEach { free($0) } }
+
+        // Save the terminal's current attributes so we can restore them after.
+        var originalTermios = termios()
+        let hasTerminal = tcgetattr(STDIN_FILENO, &originalTermios) == 0
+
+        // forkpty() creates a PTY pair and forks.
+        // Parent gets the PTY fd; child gets stdin/stdout/stderr on the other end.
+        var ptyFD: Int32 = -1
+        let pid = forkpty(&ptyFD, nil, nil, nil)
+
+        if pid == -1 {
+            return ShellResult(exitCode: 1, stdout: "", stderr: "forkpty failed: \(String(cString: strerror(errno)))")
+        }
+
+        if pid == 0 {
+            // ── Child process ──
+            if let cwd = workingDirectory {
+                chdir(cwd)
+            }
+            execve(executable, argv, envp)
+            _exit(127) // execve only returns on failure
+        }
+
+        // ── Parent process ──
+        // Put terminal in raw mode so keystrokes (including Enter for sudo)
+        // are forwarded immediately without local echo interference.
+        if hasTerminal {
+            var raw = originalTermios
+            cfmakeraw(&raw)
+            tcsetattr(STDIN_FILENO, TCSANOW, &raw)
+        }
+
+        // Ensure terminal is restored even if we exit early or the process is interrupted.
+        defer {
+            if hasTerminal {
+                tcsetattr(STDIN_FILENO, TCSANOW, &originalTermios)
+            }
+            close(ptyFD)
+        }
+
+        // Bridge I/O between the real terminal and the PTY.
+        // Uses select() to multiplex stdin → PTY and PTY → stdout.
+        let stdinFD = STDIN_FILENO
+        let stdoutFD = STDOUT_FILENO
+        var buf = [UInt8](repeating: 0, count: 4096)
+
+        bridgeLoop: while true {
+            var readSet = fd_set()
+            fdZero(&readSet)
+            fdSet(stdinFD, set: &readSet)
+            fdSet(ptyFD, set: &readSet)
+
+            let maxFD = max(stdinFD, ptyFD) + 1
+            let ready = select(maxFD, &readSet, nil, nil, nil)
+            if ready < 0 {
+                if errno == EINTR { continue } // Retry on signal (e.g. SIGWINCH)
+                break
+            }
+            if ready == 0 { continue }
+
+            // Terminal → PTY (user typing, including password input)
+            if fdIsSet(stdinFD, set: &readSet) {
+                let n = read(stdinFD, &buf, buf.count)
+                if n > 0 {
+                    _ = buf.withUnsafeBufferPointer { ptr in
+                        write(ptyFD, ptr.baseAddress!, n)
+                    }
+                }
+            }
+
+            // PTY → Terminal (command output, prompts, progress bars)
+            if fdIsSet(ptyFD, set: &readSet) {
+                let n = read(ptyFD, &buf, buf.count)
+                if n <= 0 { break bridgeLoop } // Child closed the PTY
+                _ = buf.withUnsafeBufferPointer { ptr in
+                    write(stdoutFD, ptr.baseAddress!, n)
+                }
+            }
+        }
+
+        // Wait for the child and extract exit status.
+        var status: Int32 = 0
+        waitpid(pid, &status, 0)
+        let exitCode: Int32 = if status & 0x7F == 0 {
+            // Normal exit — extract code from bits 8..15.
+            (status >> 8) & 0xFF
+        } else {
+            // Killed by signal — report as 128 + signal (shell convention).
+            128 + (status & 0x7F)
+        }
+
+        return ShellResult(exitCode: exitCode, stdout: "", stderr: "")
+    }
+
+    // MARK: - fd_set Helpers
+
+    // Swift doesn't expose FD_ZERO / FD_SET / FD_ISSET macros.
+
+    private func fdZero(_ set: inout fd_set) {
+        withUnsafeMutablePointer(to: &set) { ptr in
+            let rawPtr = UnsafeMutableRawPointer(ptr)
+            memset(rawPtr, 0, MemoryLayout<fd_set>.size)
+        }
+    }
+
+    private func fdSet(_ fd: Int32, set: inout fd_set) {
+        let intOffset = Int(fd) / (MemoryLayout<Int32>.size * 8)
+        let bitOffset = Int(fd) % (MemoryLayout<Int32>.size * 8)
+        withUnsafeMutablePointer(to: &set) { ptr in
+            let rawPtr = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: Int32.self)
+            rawPtr[intOffset] |= Int32(1 << bitOffset)
+        }
+    }
+
+    private func fdIsSet(_ fd: Int32, set: inout fd_set) -> Bool {
+        let intOffset = Int(fd) / (MemoryLayout<Int32>.size * 8)
+        let bitOffset = Int(fd) % (MemoryLayout<Int32>.size * 8)
+        return withUnsafeMutablePointer(to: &set) { ptr in
+            let rawPtr = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: Int32.self)
+            return rawPtr[intOffset] & Int32(1 << bitOffset) != 0
+        }
     }
 }

--- a/Sources/mcs/Core/ShellRunner.swift
+++ b/Sources/mcs/Core/ShellRunner.swift
@@ -84,7 +84,8 @@ struct ShellRunner: ShellRunning {
     ///
     /// - Parameter interactive: When `true`, uses `forkpty()` to allocate a
     ///   real pseudo-terminal so commands like `sudo` can prompt for passwords
-    ///   securely. Output goes directly to the terminal (not captured).
+    ///   securely. Output goes directly to the terminal (not captured); the
+    ///   returned `ShellResult` will have empty `stdout` and `stderr`.
     ///   Defaults to `false` (stdin `/dev/null`, stdout/stderr piped).
     @discardableResult
     func run(
@@ -175,6 +176,8 @@ struct ShellRunner: ShellRunning {
     /// This method uses `forkpty()` to create a real PTY pair and then
     /// bridges I/O between the parent terminal and the child's PTY so that
     /// `sudo` can properly disable echo and read passwords securely.
+    /// The returned `ShellResult` has empty `stdout` and `stderr` since
+    /// output goes directly to the terminal.
     private func runInteractive(
         executable: String,
         arguments: [String],
@@ -206,25 +209,35 @@ struct ShellRunner: ShellRunning {
         if pid == 0 {
             // ── Child process ──
             if let cwd = workingDirectory {
-                chdir(cwd)
+                if chdir(cwd) != 0 {
+                    let msg = "chdir failed: \(String(cString: strerror(errno)))\n"
+                    msg.withCString { _ = write(STDERR_FILENO, $0, strlen($0)) }
+                    _exit(126)
+                }
             }
             execve(executable, argv, envp)
-            _exit(127) // execve only returns on failure
+            let msg = "execve failed: \(String(cString: strerror(errno)))\n"
+            msg.withCString { _ = write(STDERR_FILENO, $0, strlen($0)) }
+            _exit(127)
         }
 
         // ── Parent process ──
-        // Put terminal in raw mode so keystrokes (including Enter for sudo)
-        // are forwarded immediately without local echo interference.
+        // Put terminal in raw-ish mode so keystrokes (including Enter for sudo)
+        // are forwarded immediately without local echo interference, while still
+        // allowing terminal-generated signals like Ctrl-C / Ctrl-Z.
         if hasTerminal {
             var raw = originalTermios
             cfmakeraw(&raw)
+            raw.c_lflag |= tcflag_t(ISIG)
             tcsetattr(STDIN_FILENO, TCSANOW, &raw)
         }
 
         // Ensure terminal is restored even if we exit early or the process is interrupted.
         defer {
             if hasTerminal {
-                tcsetattr(STDIN_FILENO, TCSANOW, &originalTermios)
+                if tcsetattr(STDIN_FILENO, TCSANOW, &originalTermios) != 0 {
+                    tcsetattr(STDIN_FILENO, TCSADRAIN, &originalTermios)
+                }
             }
             close(ptyFD)
         }
@@ -234,28 +247,29 @@ struct ShellRunner: ShellRunning {
         let stdinFD = STDIN_FILENO
         let stdoutFD = STDOUT_FILENO
         var buf = [UInt8](repeating: 0, count: 4096)
+        var stdinOpen = true
 
         bridgeLoop: while true {
             var readSet = fd_set()
             fdZero(&readSet)
-            fdSet(stdinFD, set: &readSet)
+            if stdinOpen { fdSet(stdinFD, set: &readSet) }
             fdSet(ptyFD, set: &readSet)
 
-            let maxFD = max(stdinFD, ptyFD) + 1
+            let maxFD = max(stdinOpen ? stdinFD : 0, ptyFD) + 1
             let ready = select(maxFD, &readSet, nil, nil, nil)
             if ready < 0 {
-                if errno == EINTR { continue } // Retry on signal (e.g. SIGWINCH)
+                if errno == EINTR { continue } // Retry on signal interruption
                 break
             }
             if ready == 0 { continue }
 
             // Terminal → PTY (user typing, including password input)
-            if fdIsSet(stdinFD, set: &readSet) {
+            if stdinOpen, fdIsSet(stdinFD, set: &readSet) {
                 let n = read(stdinFD, &buf, buf.count)
-                if n > 0 {
-                    _ = buf.withUnsafeBufferPointer { ptr in
-                        write(ptyFD, ptr.baseAddress!, n)
-                    }
+                if n <= 0 {
+                    stdinOpen = false // stdin EOF — stop monitoring
+                } else {
+                    writeAll(fd: ptyFD, buf: &buf, count: n)
                 }
             }
 
@@ -263,17 +277,17 @@ struct ShellRunner: ShellRunning {
             if fdIsSet(ptyFD, set: &readSet) {
                 let n = read(ptyFD, &buf, buf.count)
                 if n <= 0 { break bridgeLoop } // Child closed the PTY
-                _ = buf.withUnsafeBufferPointer { ptr in
-                    write(stdoutFD, ptr.baseAddress!, n)
-                }
+                writeAll(fd: stdoutFD, buf: &buf, count: n)
             }
         }
 
         // Wait for the child and extract exit status.
+        // Equivalent to WIFEXITED/WEXITSTATUS — Swift doesn't expose wait status macros.
         var status: Int32 = 0
-        waitpid(pid, &status, 0)
+        while waitpid(pid, &status, 0) < 0 {
+            if errno != EINTR { break }
+        }
         let exitCode: Int32 = if status & 0x7F == 0 {
-            // Normal exit — extract code from bits 8..15.
             (status >> 8) & 0xFF
         } else {
             // Killed by signal — report as 128 + signal (shell convention).
@@ -281,6 +295,21 @@ struct ShellRunner: ShellRunning {
         }
 
         return ShellResult(exitCode: exitCode, stdout: "", stderr: "")
+    }
+
+    /// Write all bytes to a file descriptor, retrying on partial writes and EINTR.
+    private func writeAll(fd: Int32, buf: inout [UInt8], count: Int) {
+        buf.withUnsafeBufferPointer { ptr in
+            var offset = 0
+            while offset < count {
+                let n = write(fd, ptr.baseAddress! + offset, count - offset)
+                if n < 0 {
+                    if errno == EINTR { continue }
+                    break // EIO/EPIPE — fd closed
+                }
+                offset += n
+            }
+        }
     }
 
     // MARK: - fd_set Helpers

--- a/Sources/mcs/Export/ManifestBuilder.swift
+++ b/Sources/mcs/Export/ManifestBuilder.swift
@@ -532,9 +532,12 @@ struct ManifestBuilder {
                 yaml.line("      - \(yamlQuote(entry))")
             }
 
-        case let .shellCommand(command):
+        case let .shellCommand(command, interactive):
             yaml.line("    type: \(comp.type.rawValue)")
             yaml.line("    shell: \(yamlQuote(command))")
+            if interactive {
+                yaml.line("    shellInteractive: true")
+            }
 
         case .settingsMerge:
             break

--- a/Sources/mcs/ExternalPack/ExternalPackAdapter.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackAdapter.swift
@@ -183,8 +183,8 @@ struct ExternalPackAdapter: TechPack {
         case let .brewInstall(package):
             return .brewInstall(package: package)
 
-        case let .shellCommand(command):
-            return .shellCommand(command: command)
+        case let .shellCommand(command, interactive):
+            return .shellCommand(command: command, interactive: interactive)
 
         case let .gitignoreEntries(entries):
             return .gitignoreEntries(entries: entries)

--- a/Sources/mcs/ExternalPack/ExternalPackManifest.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackManifest.swift
@@ -372,6 +372,7 @@ struct ExternalComponentDefinition: Codable {
         case mcp // Map — MCPShorthand (name inferred from id)
         case plugin // String — plugin full name
         case shell // String — shell command (requires explicit `type`)
+        case shellInteractive // Bool — inherit stdin for sudo/interactive prompts
         case hook // Map — CopyFileShorthand (fileType: .hook)
         case command // Map — CopyFileShorthand (fileType: .command)
         case skill // Map — CopyFileShorthand (fileType: .skill)
@@ -502,7 +503,8 @@ struct ExternalComponentDefinition: Codable {
         }
         if shorthand.contains(.shell) {
             let command = try shorthand.decode(String.self, forKey: .shell)
-            return ResolvedShorthand(type: nil, action: .shellCommand(command: command))
+            let interactive = try shorthand.decodeIfPresent(Bool.self, forKey: .shellInteractive) ?? false
+            return ResolvedShorthand(type: nil, action: .shellCommand(command: command, interactive: interactive))
         }
         if shorthand.contains(.hook) {
             let config = try shorthand.decode(CopyFileShorthand.self, forKey: .hook)
@@ -616,7 +618,7 @@ enum ExternalInstallAction: Codable {
     case mcpServer(ExternalMCPServerConfig)
     case plugin(name: String)
     case brewInstall(package: String)
-    case shellCommand(command: String)
+    case shellCommand(command: String, interactive: Bool = false)
     case gitignoreEntries(entries: [String])
     case settingsMerge
     case settingsFile(source: String)
@@ -627,6 +629,7 @@ enum ExternalInstallAction: Codable {
         case name
         case package
         case command
+        case interactive
         case args
         case env
         case transport
@@ -654,7 +657,8 @@ enum ExternalInstallAction: Codable {
             self = .brewInstall(package: package)
         case .shellCommand:
             let command = try container.decode(String.self, forKey: .command)
-            self = .shellCommand(command: command)
+            let interactive = try container.decodeIfPresent(Bool.self, forKey: .interactive) ?? false
+            self = .shellCommand(command: command, interactive: interactive)
         case .gitignoreEntries:
             let entries = try container.decode([String].self, forKey: .entries)
             self = .gitignoreEntries(entries: entries)
@@ -682,9 +686,12 @@ enum ExternalInstallAction: Codable {
         case let .brewInstall(package):
             try container.encode(ExternalInstallActionType.brewInstall, forKey: .type)
             try container.encode(package, forKey: .package)
-        case let .shellCommand(command):
+        case let .shellCommand(command, interactive):
             try container.encode(ExternalInstallActionType.shellCommand, forKey: .type)
             try container.encode(command, forKey: .command)
+            if interactive {
+                try container.encode(interactive, forKey: .interactive)
+            }
         case let .gitignoreEntries(entries):
             try container.encode(ExternalInstallActionType.gitignoreEntries, forKey: .type)
             try container.encode(entries, forKey: .entries)

--- a/Sources/mcs/ExternalPack/ExternalPackManifest.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackManifest.swift
@@ -372,7 +372,7 @@ struct ExternalComponentDefinition: Codable {
         case mcp // Map — MCPShorthand (name inferred from id)
         case plugin // String — plugin full name
         case shell // String — shell command (requires explicit `type`)
-        case shellInteractive // Bool — inherit stdin for sudo/interactive prompts
+        case shellInteractive // Bool — allocate PTY for commands needing terminal access (e.g. sudo)
         case hook // Map — CopyFileShorthand (fileType: .hook)
         case command // Map — CopyFileShorthand (fileType: .command)
         case skill // Map — CopyFileShorthand (fileType: .skill)

--- a/Sources/mcs/ExternalPack/PackTrustManager.swift
+++ b/Sources/mcs/ExternalPack/PackTrustManager.swift
@@ -23,7 +23,7 @@ struct PackTrustManager {
         if let components = manifest.components {
             for component in components {
                 switch component.installAction {
-                case let .shellCommand(command):
+                case let .shellCommand(command, _):
                     items.append(TrustableItem(
                         type: .shellCommand,
                         relativePath: nil,

--- a/Sources/mcs/Sync/GlobalSyncStrategy.swift
+++ b/Sources/mcs/Sync/GlobalSyncStrategy.swift
@@ -124,9 +124,13 @@ struct GlobalSyncStrategy: SyncStrategy {
                     artifacts.gitignoreEntries.append(contentsOf: entries)
                 }
 
-            case let .shellCommand(command):
-                output.dimmed("  Running \(component.displayName)...")
-                let result = shell.shell(command)
+            case let .shellCommand(command, interactive):
+                if interactive {
+                    output.plain("  Running \(component.displayName) (may prompt for your password)...")
+                } else {
+                    output.dimmed("  Running \(component.displayName)...")
+                }
+                let result = shell.shell(command, interactive: interactive)
                 if result.succeeded {
                     output.success("  \(component.displayName) installed")
                 } else {

--- a/Sources/mcs/Sync/GlobalSyncStrategy.swift
+++ b/Sources/mcs/Sync/GlobalSyncStrategy.swift
@@ -133,6 +133,8 @@ struct GlobalSyncStrategy: SyncStrategy {
                 let result = shell.shell(command, interactive: interactive)
                 if result.succeeded {
                     output.success("  \(component.displayName) installed")
+                } else if interactive {
+                    output.warn("  \(component.displayName) failed (see output above)")
                 } else {
                     output.warn("  \(component.displayName) requires manual installation:")
                     output.plain("    \(command)")

--- a/Sources/mcs/Sync/PackInstaller.swift
+++ b/Sources/mcs/Sync/PackInstaller.swift
@@ -89,9 +89,12 @@ struct PackInstaller {
         case let .brewInstall(package):
             return exec.installBrewPackage(package)
 
-        case let .shellCommand(command):
-            let result = shell.shell(command)
-            if !result.succeeded {
+        case let .shellCommand(command, interactive):
+            if interactive {
+                output.plain("  Running \(component.displayName) (may prompt for your password)...")
+            }
+            let result = shell.shell(command, interactive: interactive)
+            if !result.succeeded, !interactive {
                 output.warn(String(result.stderr.prefix(200)))
             }
             return result.succeeded

--- a/Sources/mcs/Sync/PackInstaller.swift
+++ b/Sources/mcs/Sync/PackInstaller.swift
@@ -94,8 +94,12 @@ struct PackInstaller {
                 output.plain("  Running \(component.displayName) (may prompt for your password)...")
             }
             let result = shell.shell(command, interactive: interactive)
-            if !result.succeeded, !interactive {
-                output.warn(String(result.stderr.prefix(200)))
+            if !result.succeeded {
+                if interactive {
+                    output.warn("  \(component.displayName) failed (see output above)")
+                } else {
+                    output.warn(String(result.stderr.prefix(200)))
+                }
             }
             return result.succeeded
 

--- a/Sources/mcs/Sync/ProjectSyncStrategy.swift
+++ b/Sources/mcs/Sync/ProjectSyncStrategy.swift
@@ -110,8 +110,12 @@ struct ProjectSyncStrategy: SyncStrategy {
                     output.plain("  Running \(component.displayName) (may prompt for your password)...")
                 }
                 let result = shell.shell(command, interactive: interactive)
-                if !result.succeeded, !interactive {
-                    output.warn("  \(component.displayName) failed: \(String(result.stderr.prefix(200)))")
+                if !result.succeeded {
+                    if interactive {
+                        output.warn("  \(component.displayName) failed (see output above)")
+                    } else {
+                        output.warn("  \(component.displayName) failed: \(String(result.stderr.prefix(200)))")
+                    }
                 }
 
             case .settingsMerge:

--- a/Sources/mcs/Sync/ProjectSyncStrategy.swift
+++ b/Sources/mcs/Sync/ProjectSyncStrategy.swift
@@ -105,9 +105,12 @@ struct ProjectSyncStrategy: SyncStrategy {
             case .brewInstall, .plugin:
                 break
 
-            case let .shellCommand(command):
-                let result = shell.shell(command)
-                if !result.succeeded {
+            case let .shellCommand(command, interactive):
+                if interactive {
+                    output.plain("  Running \(component.displayName) (may prompt for your password)...")
+                }
+                let result = shell.shell(command, interactive: interactive)
+                if !result.succeeded, !interactive {
                     output.warn("  \(component.displayName) failed: \(String(result.stderr.prefix(200)))")
                 }
 

--- a/Sources/mcs/TechPack/Component.swift
+++ b/Sources/mcs/TechPack/Component.swift
@@ -123,7 +123,7 @@ enum ComponentInstallAction {
     case mcpServer(MCPServerConfig)
     case plugin(name: String)
     case brewInstall(package: String)
-    case shellCommand(command: String)
+    case shellCommand(command: String, interactive: Bool = false)
     case settingsMerge(source: URL?)
     case gitignoreEntries(entries: [String])
     case copyPackFile(source: URL, destination: String, fileType: CopyFileType)

--- a/Tests/MCSTests/ExternalPackAdapterTests.swift
+++ b/Tests/MCSTests/ExternalPackAdapterTests.swift
@@ -135,6 +135,30 @@ struct ExternalPackAdapterTests {
         }
     }
 
+    @Test("Adapter passes through shellCommand interactive flag")
+    func shellCommandInteractivePassthrough() throws {
+        let manifest = manifestWithComponents([
+            ExternalComponentDefinition(
+                id: "test-pack.interactive-shell",
+                displayName: "Interactive install",
+                description: "Install with sudo",
+                type: .configuration,
+                dependencies: nil,
+                isRequired: nil,
+                installAction: .shellCommand(command: "sudo make install", interactive: true),
+                doctorChecks: nil
+            ),
+        ])
+        let (adapter, _) = try makeAdapter(manifest: manifest)
+        let component = adapter.components[0]
+        if case let .shellCommand(command, interactive) = component.installAction {
+            #expect(command == "sudo make install")
+            #expect(interactive == true)
+        } else {
+            Issue.record("Expected .shellCommand action")
+        }
+    }
+
     @Test("Adapter converts copyPackFile component with skill type")
     func copyPackFileComponent() throws {
         let manifest = manifestWithComponents([

--- a/Tests/MCSTests/ExternalPackAdapterTests.swift
+++ b/Tests/MCSTests/ExternalPackAdapterTests.swift
@@ -128,7 +128,7 @@ struct ExternalPackAdapterTests {
         ])
         let (adapter, _) = try makeAdapter(manifest: manifest)
         let component = adapter.components[0]
-        if case let .shellCommand(command) = component.installAction {
+        if case let .shellCommand(command, _) = component.installAction {
             #expect(command == "echo hello")
         } else {
             Issue.record("Expected .shellCommand action")

--- a/Tests/MCSTests/ExternalPackManifestTests.swift
+++ b/Tests/MCSTests/ExternalPackManifestTests.swift
@@ -903,7 +903,7 @@ struct ExternalPackManifestTests {
         try yaml.write(to: file, atomically: true, encoding: .utf8)
 
         let manifest = try ExternalPackManifest.load(from: file)
-        guard case let .shellCommand(command) = manifest.components?[0].installAction else {
+        guard case let .shellCommand(command, _) = manifest.components?[0].installAction else {
             Issue.record("Expected shellCommand install action")
             return
         }
@@ -2409,7 +2409,7 @@ struct ExternalPackManifestTests {
         let comp = try #require(manifest.components?.first)
 
         #expect(comp.type == .skill)
-        guard case let .shellCommand(command) = comp.installAction else {
+        guard case let .shellCommand(command, _) = comp.installAction else {
             Issue.record("Expected shellCommand"); return
         }
         #expect(command == "npx -y skills add xcodebuildmcp -g")

--- a/Tests/MCSTests/ExternalPackManifestTests.swift
+++ b/Tests/MCSTests/ExternalPackManifestTests.swift
@@ -910,6 +910,40 @@ struct ExternalPackManifestTests {
         #expect(command == "npx -y skills add my-skill -g -a claude-code -y")
     }
 
+    @Test("Deserialize shellCommand install action with interactive flag")
+    func shellCommandInteractiveAction() throws {
+        let yaml = """
+        schemaVersion: 1
+        identifier: test
+        displayName: Test
+        description: Test
+        version: "1.0.0"
+        components:
+          - id: test.install
+            displayName: Install tool
+            description: Install via interactive shell
+            type: configuration
+            installAction:
+              type: shellCommand
+              command: "curl -fsSL https://example.com/install.sh | sh"
+              interactive: true
+        """
+
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let file = tmpDir.appendingPathComponent("techpack.yaml")
+        try yaml.write(to: file, atomically: true, encoding: .utf8)
+
+        let manifest = try ExternalPackManifest.load(from: file)
+        guard case let .shellCommand(command, interactive) = manifest.components?[0].installAction else {
+            Issue.record("Expected shellCommand install action")
+            return
+        }
+        #expect(command == "curl -fsSL https://example.com/install.sh | sh")
+        #expect(interactive == true)
+    }
+
     @Test("Deserialize gitignoreEntries install action")
     func gitignoreEntriesAction() throws {
         let yaml = """
@@ -2413,6 +2447,68 @@ struct ExternalPackManifestTests {
             Issue.record("Expected shellCommand"); return
         }
         #expect(command == "npx -y skills add xcodebuildmcp -g")
+    }
+
+    @Test("Shorthand shell: shellInteractive true is decoded")
+    func shorthandShellInteractiveTrue() throws {
+        let yaml = """
+        schemaVersion: 1
+        identifier: my-pack
+        displayName: My Pack
+        description: Test
+        version: "1.0.0"
+        components:
+          - id: my-pack.installer
+            description: Install via interactive shell
+            type: configuration
+            shell: "sudo make install"
+            shellInteractive: true
+        """
+
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let file = tmpDir.appendingPathComponent("techpack.yaml")
+        try yaml.write(to: file, atomically: true, encoding: .utf8)
+
+        let manifest = try ExternalPackManifest.load(from: file)
+        let comp = try #require(manifest.components?.first)
+
+        guard case let .shellCommand(command, interactive) = comp.installAction else {
+            Issue.record("Expected shellCommand"); return
+        }
+        #expect(command == "sudo make install")
+        #expect(interactive == true)
+    }
+
+    @Test("Shorthand shell: shellInteractive defaults to false when omitted")
+    func shorthandShellInteractiveDefaultsFalse() throws {
+        let yaml = """
+        schemaVersion: 1
+        identifier: my-pack
+        displayName: My Pack
+        description: Test
+        version: "1.0.0"
+        components:
+          - id: my-pack.tool
+            description: Install via shell
+            type: configuration
+            shell: "echo hello"
+        """
+
+        let tmpDir = try makeTmpDir()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let file = tmpDir.appendingPathComponent("techpack.yaml")
+        try yaml.write(to: file, atomically: true, encoding: .utf8)
+
+        let manifest = try ExternalPackManifest.load(from: file)
+        let comp = try #require(manifest.components?.first)
+
+        guard case let .shellCommand(_, interactive) = comp.installAction else {
+            Issue.record("Expected shellCommand"); return
+        }
+        #expect(interactive == false)
     }
 
     // MARK: - Shorthand: hook

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -960,8 +960,8 @@ struct ShellCommandLifecycleTests {
         #expect(FileManager.default.fileExists(atPath: markerPath))
     }
 
-    @Test("shellCommand with interactive flag shows password prompt message")
-    func shellCommandInteractiveMessage() throws {
+    @Test("shellCommand with interactive flag is accepted and state is recorded")
+    func shellCommandInteractiveAccepted() throws {
         let bed = try LifecycleTestBed()
         defer { bed.cleanup() }
 

--- a/Tests/MCSTests/LifecycleIntegrationTests.swift
+++ b/Tests/MCSTests/LifecycleIntegrationTests.swift
@@ -913,6 +913,88 @@ struct GlobalScopeLifecycleTests {
     }
 }
 
+// MARK: - Scenario 5b: Shell Command Component Lifecycle
+
+struct ShellCommandLifecycleTests {
+    @Test("shellCommand component executes during global sync and survives re-sync")
+    func shellCommandGlobalSync() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        // Use a harmless shell command that creates a marker file
+        let markerPath = bed.home.appendingPathComponent("shell-marker.txt").path
+        let pack = MockTechPack(
+            identifier: "shell-pack",
+            displayName: "Shell Pack",
+            components: [
+                ComponentDefinition(
+                    id: "shell-pack.install",
+                    displayName: "Shell install",
+                    description: "Install via shell",
+                    type: .configuration,
+                    packIdentifier: "shell-pack",
+                    dependencies: [],
+                    isRequired: true,
+                    installAction: .shellCommand(command: "touch '\(markerPath)'")
+                ),
+            ]
+        )
+        let registry = TechPackRegistry(packs: [pack])
+
+        // === Configure ===
+        let configurator = bed.makeGlobalSyncConfigurator(registry: registry)
+        try configurator.configure(packs: [pack], confirmRemovals: false)
+
+        // Verify the shell command ran
+        #expect(FileManager.default.fileExists(atPath: markerPath))
+
+        // Verify state
+        let state = try ProjectState(stateFile: bed.env.globalStateFile)
+        #expect(state.configuredPacks.contains("shell-pack"))
+
+        // === Re-sync (idempotent) ===
+        try FileManager.default.removeItem(atPath: markerPath)
+        try configurator.configure(packs: [pack], confirmRemovals: false)
+
+        // Shell command re-runs (no isAlreadyInstalled skip without doctorChecks)
+        #expect(FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    @Test("shellCommand with interactive flag shows password prompt message")
+    func shellCommandInteractiveMessage() throws {
+        let bed = try LifecycleTestBed()
+        defer { bed.cleanup() }
+
+        let markerPath = bed.home.appendingPathComponent("interactive-marker.txt").path
+        let pack = MockTechPack(
+            identifier: "interactive-pack",
+            displayName: "Interactive Pack",
+            components: [
+                ComponentDefinition(
+                    id: "interactive-pack.install",
+                    displayName: "Interactive install",
+                    description: "Install with interactive flag",
+                    type: .configuration,
+                    packIdentifier: "interactive-pack",
+                    dependencies: [],
+                    isRequired: true,
+                    installAction: .shellCommand(command: "touch '\(markerPath)'", interactive: true)
+                ),
+            ]
+        )
+        let registry = TechPackRegistry(packs: [pack])
+
+        // Configure — interactive commands use forkpty() in real ShellRunner,
+        // but the test verifies the component is accepted and state is recorded.
+        let configurator = bed.makeGlobalSyncConfigurator(registry: registry)
+        try configurator.configure(packs: [pack], confirmRemovals: false)
+
+        // Verify state records the pack
+        let state = try ProjectState(stateFile: bed.env.globalStateFile)
+        #expect(state.configuredPacks.contains("interactive-pack"))
+    }
+}
+
 // MARK: - Scenario 6: Stale Artifact Cleanup on Pack Update
 
 struct StaleArtifactCleanupTests {

--- a/Tests/MCSTests/TestHelpers.swift
+++ b/Tests/MCSTests/TestHelpers.swift
@@ -109,7 +109,8 @@ final class MockShellRunner: ShellRunning, @unchecked Sendable {
         _ executable: String,
         arguments: [String],
         workingDirectory: String?,
-        additionalEnvironment: [String: String]
+        additionalEnvironment: [String: String],
+        interactive _: Bool
     ) -> ShellResult {
         runCalls.append(RunCall(
             executable: executable,
@@ -127,7 +128,8 @@ final class MockShellRunner: ShellRunning, @unchecked Sendable {
     func shell(
         _ command: String,
         workingDirectory: String?,
-        additionalEnvironment: [String: String]
+        additionalEnvironment: [String: String],
+        interactive _: Bool
     ) -> ShellResult {
         shellCalls.append(ShellCall(
             command: command,

--- a/Tests/MCSTests/TestHelpers.swift
+++ b/Tests/MCSTests/TestHelpers.swift
@@ -69,12 +69,14 @@ final class MockShellRunner: ShellRunning, @unchecked Sendable {
         let arguments: [String]
         let workingDirectory: String?
         let additionalEnvironment: [String: String]
+        let interactive: Bool
     }
 
     struct ShellCall: Equatable {
         let command: String
         let workingDirectory: String?
         let additionalEnvironment: [String: String]
+        let interactive: Bool
     }
 
     let environment: Environment
@@ -110,13 +112,14 @@ final class MockShellRunner: ShellRunning, @unchecked Sendable {
         arguments: [String],
         workingDirectory: String?,
         additionalEnvironment: [String: String],
-        interactive _: Bool
+        interactive: Bool
     ) -> ShellResult {
         runCalls.append(RunCall(
             executable: executable,
             arguments: arguments,
             workingDirectory: workingDirectory,
-            additionalEnvironment: additionalEnvironment
+            additionalEnvironment: additionalEnvironment,
+            interactive: interactive
         ))
         if !runResults.isEmpty {
             return runResults.removeFirst()
@@ -129,12 +132,13 @@ final class MockShellRunner: ShellRunning, @unchecked Sendable {
         _ command: String,
         workingDirectory: String?,
         additionalEnvironment: [String: String],
-        interactive _: Bool
+        interactive: Bool
     ) -> ShellResult {
         shellCalls.append(ShellCall(
             command: command,
             workingDirectory: workingDirectory,
-            additionalEnvironment: additionalEnvironment
+            additionalEnvironment: additionalEnvironment,
+            interactive: interactive
         ))
         if !shellResults.isEmpty {
             return shellResults.removeFirst()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,7 +201,7 @@ enum ComponentInstallAction {
     case mcpServer(MCPServerConfig)     // Register via `claude mcp add -s <scope>`
     case plugin(name: String)            // Install via `claude plugin install`
     case brewInstall(package: String)    // Install via Homebrew
-    case shellCommand(command: String)   // Run arbitrary shell command
+    case shellCommand(command: String, interactive: Bool = false)  // Run shell command (interactive: PTY for sudo)
     case settingsMerge                   // Deep-merge settings (project-level)
     case gitignoreEntries(entries)       // Add to global gitignore
     case copyPackFile(source, dest, type) // Copy from pack checkout to project .claude/

--- a/docs/creating-tech-packs.md
+++ b/docs/creating-tech-packs.md
@@ -136,6 +136,21 @@ Need to depend on Homebrew itself? That's a special case — Homebrew can't inst
         command: brew
 ```
 
+If the install script may need `sudo` (e.g. creating symlinks in `/usr/local/bin`), add `shellInteractive: true` to allocate a real terminal so password prompts work correctly:
+
+```yaml
+  - id: ollama
+    description: Local LLM runtime
+    type: configuration
+    shell: "curl -fsSL https://ollama.com/install.sh | sh"
+    shellInteractive: true
+    doctorChecks:
+      - type: commandExists
+        name: Ollama installed
+        command: ollama
+        args: ["--version"]
+```
+
 ### MCP Servers
 
 Register MCP servers with the Claude CLI:

--- a/docs/techpack-schema.md
+++ b/docs/techpack-schema.md
@@ -256,10 +256,26 @@ Infers: `type: configuration`, `installAction: gitignoreEntries`
 | Field | Type | Description |
 |-------|------|-------------|
 | `shell` | `String` | Shell command to execute |
+| `shellInteractive` | `Bool` | When `true`, allocates a PTY so commands like `sudo` can prompt for passwords securely. Default: `false` |
 
 **Does not infer `type`** — you must provide `type:` explicitly. This is because a shell command could install anything (a brew package, a skill, a tool).
 
 No auto-derived doctor check — add `doctorChecks` if verification is needed.
+
+Use `shellInteractive: true` when the command may need terminal access (e.g. install scripts that use `sudo`):
+
+```yaml
+- id: ollama
+  description: Local LLM runtime
+  type: configuration
+  shell: "curl -fsSL https://ollama.com/install.sh | sh"
+  shellInteractive: true
+  doctorChecks:
+    - type: commandExists
+      name: "Ollama installed"
+      command: ollama
+      args: ["--version"]
+```
 
 ---
 
@@ -284,7 +300,7 @@ The explicit form with `type` + `installAction` is always supported:
 | `mcpServer` | `name`, `command`, `args`, `env`, `transport`, `url`, `scope` | Register MCP server |
 | `plugin` | `name` | Install Claude Code plugin |
 | `brewInstall` | `package` | Install Homebrew package |
-| `shellCommand` | `command` | Run shell command |
+| `shellCommand` | `command`, `interactive` | Run shell command (`interactive`: allocate PTY, default `false`) |
 | `gitignoreEntries` | `entries` | Add to global gitignore |
 | `settingsMerge` | *(none)* | Merge settings (internal) |
 | `settingsFile` | `source` | Merge settings from file |


### PR DESCRIPTION
## Summary

Adds a `shellInteractive` YAML key for tech pack `shell:` components that need terminal access (e.g. install scripts requiring `sudo`). When enabled, mcs uses `forkpty()` to allocate a real pseudo-terminal so commands can prompt for passwords securely with proper echo control.

## Changes

- Add `interactive: Bool` associated value to `ComponentInstallAction.shellCommand` and `ExternalInstallAction.shellCommand` (defaults to `false` — fully backward-compatible)
- Add `shellInteractive` shorthand key to `ExternalComponentDefinition` for YAML packs
- Thread `interactive` through `ShellRunning` protocol, all sync strategies, `PackInstaller`, and `ManifestBuilder` export
- Add `runInteractive()` to `ShellRunner` using `forkpty()` + `select()` I/O bridge with raw-mode terminal, EINTR handling, proper `WIFEXITED`/`WIFSIGNALED` exit status, and defer-based terminal restoration
- Show "may prompt for your password" message before interactive commands; suppress empty stderr warnings for interactive failures

## Test plan

- [x] `swift test` passes locally (978 tests)
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [x] Tested `mcs sync --global` with a pack using `shellInteractive: true` — sudo prompt works, password is hidden, install completes successfully
- [x] Verified non-interactive shell commands are unaffected (default `interactive: false`)
- [x] Verified `mcs doctor` does not trigger side effects from interactive components

<details>
<summary>Checklist for engine changes</summary>

- [x] `.shellCommand` components have `supplementaryDoctorChecks` defined (`deriveDoctorCheck()` returns `nil` for shell actions)
- [x] Docs updated if behavior changed (`CLAUDE.md`, `docs/`, `techpack.yaml` schema in `ExternalPackManifest.swift`)

</details>

### Tech pack YAML syntax

```yaml
- id: my-tool
  type: configuration
  shell: "curl -fsSL https://example.com/install.sh | sh"
  shellInteractive: true  # allocates PTY for sudo prompts
```