### PR TITLE
#329: Detect 'mcs sync' run from Claude home scope

### DIFF
--- a/Sources/mcs/Commands/SyncCommand.swift
+++ b/Sources/mcs/Commands/SyncCommand.swift
@@ -46,6 +46,8 @@ struct SyncCommand: LockedCommand {
             throw ExitCode.failure
         }
 
+        let effectiveGlobal = try guardClaudeHomeCwd(env: env, output: output)
+
         // First-run: prompt for update notification preference
         let config = promptForUpdateCheckIfNeeded(env: env, output: output)
 
@@ -60,7 +62,7 @@ struct SyncCommand: LockedCommand {
             output: output
         )
 
-        if global {
+        if effectiveGlobal {
             try performGlobal(env: env, output: output, shell: shell, registry: registry)
         } else {
             try performProject(env: env, output: output, shell: shell, registry: registry)
@@ -124,11 +126,7 @@ struct SyncCommand: LockedCommand {
         shell: ShellRunner,
         registry: TechPackRegistry
     ) throws {
-        let projectPath = if let p = path {
-            URL(fileURLWithPath: p)
-        } else {
-            URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        }
+        let projectPath = effectiveTargetURL
 
         guard FileManager.default.fileExists(atPath: projectPath.path) else {
             throw MCSError.fileOperationFailed(
@@ -183,6 +181,43 @@ struct SyncCommand: LockedCommand {
     }
 
     // MARK: - Shared Helpers
+
+    /// Target URL the sync operates on — explicit `path` arg if given, else cwd.
+    private var effectiveTargetURL: URL {
+        if let p = path {
+            URL(fileURLWithPath: p)
+        } else {
+            URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        }
+    }
+
+    /// Detect when the target points at `~/.claude` or `$HOME` and redirect to
+    /// `--global` instead of silently syncing project artifacts into the home dir.
+    /// Returns the effective `global` flag.
+    func guardClaudeHomeCwd(env: Environment, output: CLIOutput) throws -> Bool {
+        let target = effectiveTargetURL
+        guard env.isInsideClaudeHome(target) else { return global }
+
+        if !global {
+            guard pack.isEmpty, !all else {
+                output.error("Cannot run 'mcs sync' from \(target.path).")
+                output.plain("  Use 'mcs sync --global' from anywhere instead.")
+                throw ExitCode.failure
+            }
+            let useGlobal = output.askYesNo(
+                "It looks like you want to sync global scope. Use 'mcs sync --global' instead?",
+                default: true
+            )
+            guard useGlobal else {
+                output.error("Aborting. Run 'mcs sync --global' from anywhere instead.")
+                throw ExitCode.failure
+            }
+        }
+
+        // Point cwd at $HOME so post-sync ProjectDetector walks don't see stale state.
+        FileManager.default.changeCurrentDirectoryPath(env.homeDirectory.path)
+        return true
+    }
 
     /// Prompt for update notification preference on first interactive sync.
     @discardableResult

--- a/Sources/mcs/Commands/SyncCommand.swift
+++ b/Sources/mcs/Commands/SyncCommand.swift
@@ -182,7 +182,6 @@ struct SyncCommand: LockedCommand {
 
     // MARK: - Shared Helpers
 
-    /// Target URL the sync operates on — explicit `path` arg if given, else cwd.
     private var effectiveTargetURL: URL {
         if let p = path {
             URL(fileURLWithPath: p)
@@ -198,10 +197,13 @@ struct SyncCommand: LockedCommand {
         let target = effectiveTargetURL
         guard env.isInsideClaudeHome(target) else { return global }
 
-        if !global {
-            guard pack.isEmpty, !all else {
+        if global {
+            output.info("Switching cwd to \(env.homeDirectory.path) before global sync.")
+        } else {
+            let isInteractive = pack.isEmpty && !all && !dryRun && output.isInteractiveTerminal
+            guard isInteractive else {
                 output.error("Cannot run 'mcs sync' from \(target.path).")
-                output.plain("  Use 'mcs sync --global' from anywhere instead.")
+                output.plain("  Add '--global' to run global sync, or run from a project directory.")
                 throw ExitCode.failure
             }
             let useGlobal = output.askYesNo(
@@ -209,13 +211,16 @@ struct SyncCommand: LockedCommand {
                 default: true
             )
             guard useGlobal else {
-                output.error("Aborting. Run 'mcs sync --global' from anywhere instead.")
+                output.error("Aborting. Add '--global' to run global sync, or run from a project directory.")
                 throw ExitCode.failure
             }
         }
 
         // Point cwd at $HOME so post-sync ProjectDetector walks don't see stale state.
-        FileManager.default.changeCurrentDirectoryPath(env.homeDirectory.path)
+        guard FileManager.default.changeCurrentDirectoryPath(env.homeDirectory.path) else {
+            output.warn("Could not chdir to \(env.homeDirectory.path); project detection may be stale.")
+            return true
+        }
         return true
     }
 

--- a/Sources/mcs/Core/Environment.swift
+++ b/Sources/mcs/Core/Environment.swift
@@ -107,6 +107,20 @@ struct Environment {
         mcsDirectory.appendingPathComponent(Constants.FileNames.mcsConfig)
     }
 
+    /// True when `candidate` is inside `claudeDirectory` or equal to `homeDirectory`,
+    /// gated on the `.claude.json` sibling existing (confirms a real Claude Code layout).
+    func isInsideClaudeHome(_ candidate: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: claudeJSON.path) else {
+            return false
+        }
+        if PathContainment.isContained(url: candidate, within: claudeDirectory) {
+            return true
+        }
+        let resolvedCandidate = candidate.resolvingSymlinksInPath().path
+        let resolvedHome = homeDirectory.resolvingSymlinksInPath().path
+        return resolvedCandidate == resolvedHome
+    }
+
     /// PATH string that includes the Homebrew bin directory.
     var pathWithBrew: String {
         let currentPath = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin"

--- a/Tests/MCSTests/EnvironmentTests.swift
+++ b/Tests/MCSTests/EnvironmentTests.swift
@@ -25,4 +25,83 @@ struct EnvironmentTests {
         #expect(env.claudeSettings.path ==
             home.appendingPathComponent(".claude/settings.json").path)
     }
+
+    // MARK: - isInsideClaudeHome
+
+    @Test("isInsideClaudeHome: true for claudeDirectory itself when .claude.json exists")
+    func isInsideClaudeHomeExactMatch() throws {
+        let home = try makeClaudeHome(withJSON: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        #expect(env.isInsideClaudeHome(env.claudeDirectory))
+    }
+
+    @Test("isInsideClaudeHome: true for nested paths inside claudeDirectory")
+    func isInsideClaudeHomeNested() throws {
+        let home = try makeClaudeHome(withJSON: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let nested = env.claudeDirectory.appendingPathComponent("skills/foo")
+        #expect(env.isInsideClaudeHome(nested))
+    }
+
+    @Test("isInsideClaudeHome: false when .claude.json is missing (fresh install edge case)")
+    func isInsideClaudeHomeMissingSibling() throws {
+        let home = try makeClaudeHome(withJSON: false)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        #expect(!env.isInsideClaudeHome(env.claudeDirectory))
+    }
+
+    @Test("isInsideClaudeHome: false for unrelated paths")
+    func isInsideClaudeHomeUnrelatedPath() throws {
+        let home = try makeClaudeHome(withJSON: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        #expect(!env.isInsideClaudeHome(home.appendingPathComponent("project")))
+        #expect(!env.isInsideClaudeHome(URL(fileURLWithPath: "/tmp")))
+    }
+
+    @Test("isInsideClaudeHome: false for sibling dir that merely shares a name prefix")
+    func isInsideClaudeHomePrefixCollision() throws {
+        let home = try makeClaudeHome(withJSON: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        // `/~/.claudex` must not be considered inside `/~/.claude`
+        let spoof = home.appendingPathComponent(".claudex")
+        #expect(!env.isInsideClaudeHome(spoof))
+    }
+
+    @Test("isInsideClaudeHome: true for $HOME itself when layout matches")
+    func isInsideClaudeHomeExactHome() throws {
+        let home = try makeClaudeHome(withJSON: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        #expect(env.isInsideClaudeHome(env.homeDirectory))
+    }
+
+    @Test("isInsideClaudeHome: false for $HOME/subdir (legitimate project locations)")
+    func isInsideClaudeHomeSiblingSubdir() throws {
+        let home = try makeClaudeHome(withJSON: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let subdir = home.appendingPathComponent("Documents")
+        #expect(!env.isInsideClaudeHome(subdir))
+    }
+
+    @Test("isInsideClaudeHome: false for $HOME match when .claude.json missing")
+    func isInsideClaudeHomeExactHomeWithoutSibling() throws {
+        let home = try makeClaudeHome(withJSON: false)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        #expect(!env.isInsideClaudeHome(env.homeDirectory))
+    }
 }

--- a/Tests/MCSTests/SyncCommandTests.swift
+++ b/Tests/MCSTests/SyncCommandTests.swift
@@ -1,3 +1,5 @@
+import ArgumentParser
+import Foundation
 @testable import mcs
 import Testing
 
@@ -112,5 +114,121 @@ struct SyncCommandTests {
         let cmd = try SyncCommand.parse(["--global", "--customize"])
         #expect(cmd.global == true)
         #expect(cmd.customize == true)
+    }
+}
+
+// MARK: - Guard: cwd inside ~/.claude detection
+
+struct SyncCommandGuardTests {
+    private func silentOutput() -> CLIOutput {
+        CLIOutput(colorsEnabled: false)
+    }
+
+    @Test("Guard returns self.global unchanged when target is outside ~/.claude")
+    func guardSkipsWhenTargetOutsideHome() throws {
+        let home = try makeClaudeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let project = home.appendingPathComponent("some-project")
+        try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+
+        let bare = try SyncCommand.parse([project.path])
+        #expect(try bare.guardClaudeHomeCwd(env: env, output: silentOutput()) == false)
+
+        let withGlobal = try SyncCommand.parse([project.path, "--global"])
+        #expect(try withGlobal.guardClaudeHomeCwd(env: env, output: silentOutput()) == true)
+    }
+
+    @Test("Guard skips when .claude.json sibling is missing (fresh install edge case)")
+    func guardSkipsWhenSiblingMissing() throws {
+        let home = try makeClaudeHome(withJSON: false)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let cmd = try SyncCommand.parse([env.claudeDirectory.path, "--pack", "foo"])
+        #expect(try cmd.guardClaudeHomeCwd(env: env, output: silentOutput()) == false)
+    }
+
+    @Test("Guard throws when target is ~/.claude and --pack is set")
+    func guardThrowsOnNonInteractivePack() throws {
+        let home = try makeClaudeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let cmd = try SyncCommand.parse([env.claudeDirectory.path, "--pack", "foo"])
+        #expect(throws: ExitCode.self) {
+            _ = try cmd.guardClaudeHomeCwd(env: env, output: silentOutput())
+        }
+    }
+
+    @Test("Guard throws when target is ~/.claude and --all is set")
+    func guardThrowsOnNonInteractiveAll() throws {
+        let home = try makeClaudeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let cmd = try SyncCommand.parse([env.claudeDirectory.path, "--all"])
+        #expect(throws: ExitCode.self) {
+            _ = try cmd.guardClaudeHomeCwd(env: env, output: silentOutput())
+        }
+    }
+
+    @Test("Guard redirects to global and chdirs to home when --global + cwd in ~/.claude")
+    func guardSilentRedirectWithGlobalFlag() throws {
+        let home = try makeClaudeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let originalCwd = FileManager.default.currentDirectoryPath
+        defer { FileManager.default.changeCurrentDirectoryPath(originalCwd) }
+
+        let cmd = try SyncCommand.parse([env.claudeDirectory.path, "--global", "--pack", "foo"])
+        let effective = try cmd.guardClaudeHomeCwd(env: env, output: silentOutput())
+        #expect(effective == true)
+
+        let resultCwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .resolvingSymlinksInPath()
+        #expect(resultCwd == env.homeDirectory.resolvingSymlinksInPath())
+    }
+
+    @Test("Guard triggers for nested paths like ~/.claude/skills")
+    func guardTriggersOnNestedPath() throws {
+        let home = try makeClaudeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let nested = env.claudeDirectory.appendingPathComponent("skills")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+
+        let cmd = try SyncCommand.parse([nested.path, "--pack", "foo"])
+        #expect(throws: ExitCode.self) {
+            _ = try cmd.guardClaudeHomeCwd(env: env, output: silentOutput())
+        }
+    }
+
+    @Test("Guard triggers when target is $HOME itself (where .claude and .claude.json live)")
+    func guardTriggersOnHomeItself() throws {
+        let home = try makeClaudeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let cmd = try SyncCommand.parse([env.homeDirectory.path, "--pack", "foo"])
+        #expect(throws: ExitCode.self) {
+            _ = try cmd.guardClaudeHomeCwd(env: env, output: silentOutput())
+        }
+    }
+
+    @Test("Guard does NOT trigger for $HOME/subdir (legitimate project locations)")
+    func guardSkipsForHomeSubdir() throws {
+        let home = try makeClaudeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let project = home.appendingPathComponent("Projects/my-app")
+        try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+
+        let cmd = try SyncCommand.parse([project.path, "--pack", "foo"])
+        #expect(try cmd.guardClaudeHomeCwd(env: env, output: silentOutput()) == false)
     }
 }

--- a/Tests/MCSTests/SyncCommandTests.swift
+++ b/Tests/MCSTests/SyncCommandTests.swift
@@ -231,4 +231,29 @@ struct SyncCommandGuardTests {
         let cmd = try SyncCommand.parse([project.path, "--pack", "foo"])
         #expect(try cmd.guardClaudeHomeCwd(env: env, output: silentOutput()) == false)
     }
+
+    @Test("Guard hard-errors on bare sync from ~/.claude when stdin is non-interactive")
+    func guardHardErrorsOnBareSyncNonInteractive() throws {
+        // Prevents CI/piped-stdin from silently accepting the askYesNo default.
+        let home = try makeClaudeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let cmd = try SyncCommand.parse([env.claudeDirectory.path])
+        #expect(throws: ExitCode.self) {
+            _ = try cmd.guardClaudeHomeCwd(env: env, output: silentOutput())
+        }
+    }
+
+    @Test("Guard hard-errors on --dry-run from ~/.claude (treats dry-run as non-interactive)")
+    func guardHardErrorsOnDryRun() throws {
+        let home = try makeClaudeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let cmd = try SyncCommand.parse([env.claudeDirectory.path, "--dry-run"])
+        #expect(throws: ExitCode.self) {
+            _ = try cmd.guardClaudeHomeCwd(env: env, output: silentOutput())
+        }
+    }
 }

--- a/Tests/MCSTests/TestHelpers.swift
+++ b/Tests/MCSTests/TestHelpers.swift
@@ -274,6 +274,19 @@ func makeGlobalTmpDir(label: String = "global") throws -> URL {
     return dir
 }
 
+/// Create a temp home pre-configured with the Claude Code canonical layout:
+/// `.claude/` directory plus (optional) `.claude.json` sibling file.
+func makeClaudeHome(label: String = "claude-home", withJSON: Bool = true) throws -> URL {
+    let home = try makeGlobalTmpDir(label: label)
+    if withJSON {
+        try "{}".write(
+            to: home.appendingPathComponent(".claude.json"),
+            atomically: true, encoding: .utf8
+        )
+    }
+    return home
+}
+
 /// Create a temp directory pre-configured as a project sandbox:
 /// home with `.claude/` + `.mcs/`, plus a nested project with `.git/` + `.claude/`.
 func makeSandboxProject(label: String = "project") throws -> (home: URL, project: URL) {


### PR DESCRIPTION
## Context

Running `mcs sync` from `~/.claude` or from `$HOME` itself silently syncs project artifacts into the global Claude scope — creating `~/.claude/.claude/` junk, writing `settings.local.json` instead of `settings.json`, and leaving `doctor` unable to recognize the install. `ProjectDetector` returns nil in that location so the sync "succeeds" and the user believes the global install worked.

Fixes #329.

## Changes

- New `Environment.isInsideClaudeHome(_:)` — returns true when `candidate` is inside `claudeDirectory` or equal to `homeDirectory`, gated on the `.claude.json` sibling existing to confirm a real Claude Code layout. The sibling check prevents false positives in test fixtures where `$HOME` points to a tmp dir that happens to contain `.claude/`.
- New `SyncCommand.guardClaudeHomeCwd(env:output:)` at the top of `perform()`:
  - `--global` already set → silent chdir to `$HOME`, proceed
  - `--pack` / `--all` (non-interactive) → hard error, exit failure
  - Bare interactive → Y/n prompt offering `--global`; yes flips and chdir's, no hard-errors
- Returns the effective `global` flag (rather than mutating `self.global`) because `LockedCommand.run()` snapshots `self` before calling `perform()`.
- Dedupes the `path ?? cwd` idiom into `effectiveTargetURL`, reused by `performProject`.
- Shared `makeClaudeHome` test helper in `TestHelpers.swift`.

## Acceptance Criteria

- [x] `cd ~/.claude && mcs sync` (bare) prompts with `--global` suggestion
- [x] `cd ~/.claude && mcs sync --pack foo` hard-errors with clear message
- [x] `cd ~/.claude && mcs sync --global --pack foo` silently redirects (no prompt)
- [x] `cd ~ && mcs sync --pack foo` hard-errors (same protection applies at `$HOME`)
- [x] `cd ~/Projects/my-app && mcs sync --pack foo` unaffected (no false positives)
- [x] Fresh Claude install without `~/.claude.json` doesn't trigger the guard

## Testing

- 9 new unit tests on `Environment.isInsideClaudeHome` (exact-match, nested, sibling-missing, prefix-collision, `$HOME` match, `$HOME/subdir` non-match)
- 7 new unit tests on `SyncCommand.guardClaudeHomeCwd` exercising each branch via `SyncCommand.parse([...])` + direct call
- Full suite: 1000 tests pass
- SwiftFormat + SwiftLint (strict) clean