### PR TITLE
#328: Delta-aware picker + confirmation for mcs sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ mcs config set <key> <value>     # Set a configuration value (true/false)
 - `PackUpdater.swift` — shared fetch → validate → trust cycle for updating a single git pack (used by `UpdatePack` and `LockfileOperations`)
 - `ResourceRefCounter.swift` — two-tier reference counting (global artifacts + project index manifests) for safe brew/plugin removal
 - `LockfileOperations.swift` — reads/writes `mcs.lock.yaml`, checks out locked versions, updates lockfile
+- `SyncDeltaSummary.swift` — computes add/remove/keep deltas between previous and selected pack sets and renders the review-changes summary shown before destructive sync operations
 
 ### Templates (`Sources/mcs/Templates/`)
 - `TemplateEngine.swift` — `__PLACEHOLDER__` substitution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ mcs config set <key> <value>     # Set a configuration value (true/false)
 
 ### Core (`Sources/mcs/Core/`)
 - `Constants.swift` — centralized string constants (file names, CLI paths, JSON keys, external packs, plugins)
-- `Environment.swift` — paths, arch detection, brew path
+- `Environment.swift` — paths, arch detection, brew path, claude-home cwd detection (`isInsideClaudeHome(_:)`)
 - `CLIOutput.swift` — ANSI colors, logging, prompts, multi-select, doctor summary
 - `ShellRunner.swift` — Process execution wrapper
 - `Settings.swift` — Codable model for `settings.json` and `settings.local.json`, deep-merge
@@ -114,7 +114,7 @@ mcs config set <key> <value>     # Set a configuration value (true/false)
 - `SectionValidator.swift` — validation of CLAUDE.local.md section markers
 
 ### Commands (`Sources/mcs/Commands/`)
-- `SyncCommand.swift` — primary command (`mcs sync`), handles both project-scoped and global-scoped sync with `--pack`, `--all`, `--dry-run`, `--customize`, `--global`, `--lock`, `--update` flags
+- `SyncCommand.swift` — primary command (`mcs sync`), handles both project-scoped and global-scoped sync with `--pack`, `--all`, `--dry-run`, `--customize`, `--global`, `--lock`, `--update` flags. `guardClaudeHomeCwd()` at the top of `perform()` rejects/redirects runs from `~/.claude` or `$HOME` to prevent silent corruption of the global scope
 - `DoctorCommand.swift` — health checks with optional --fix and --pack filter
 - `CleanupCommand.swift` — backup file management with --force flag
 - `PackCommand.swift` — `mcs pack add/remove/list/update/validate` subcommands; uses `PackSourceResolver` for 3-tier input detection (URL schemes → filesystem paths → GitHub shorthand)

--- a/Sources/mcs/Core/CLIOutput.swift
+++ b/Sources/mcs/Core/CLIOutput.swift
@@ -3,6 +3,11 @@ import Foundation
 /// Terminal output with ANSI color support and structured logging.
 struct CLIOutput {
     let colorsEnabled: Bool
+    /// True when stdin is a TTY — i.e. the user can answer prompts (raw or fallback).
+    /// Gate interactive-confirmation flows on this, not on `isInteractiveTerminal`.
+    let hasInteractiveStdin: Bool
+    /// True when both stdin and stdout are TTYs — the raw-terminal UI (cursor
+    /// manipulation, ANSI ornamentation) can render. Gate pickers on this.
     let isInteractiveTerminal: Bool
     let style: ANSIStyle
 
@@ -12,7 +17,8 @@ struct CLIOutput {
         } else {
             self.colorsEnabled = isatty(STDOUT_FILENO) != 0
         }
-        isInteractiveTerminal = self.colorsEnabled && isatty(STDIN_FILENO) != 0
+        hasInteractiveStdin = isatty(STDIN_FILENO) != 0
+        isInteractiveTerminal = hasInteractiveStdin && isatty(STDOUT_FILENO) != 0
         style = ANSIStyle(enabled: self.colorsEnabled)
     }
 
@@ -545,8 +551,7 @@ struct CLIOutput {
                     switch state {
                     case .newInstall: additions += 1
                     case .installedRemoved: removals += 1
-                    case .installedKept: unchanged += 1
-                    case .notInstalled: break
+                    case .installedKept, .notInstalled: unchanged += 1
                     }
                 }
                 if isCursor, group.showsDelta {

--- a/Sources/mcs/Core/CLIOutput.swift
+++ b/Sources/mcs/Core/CLIOutput.swift
@@ -512,20 +512,45 @@ struct CLIOutput {
         columns: Int
     ) -> String {
         var output = ""
+        let style = ANSIStyle(enabled: colorsEnabled)
 
         var flatIndex = 0
+        var cursorRowState: PickerDelta.RowState?
+        var additions = 0
+        var removals = 0
+        var unchanged = 0
+
         for group in groups where !group.items.isEmpty {
             output += "\n"
             output += sectionHeaderString(group.title)
             for item in group.items {
                 let isCursor = flatIndex == cursor
+                let state = PickerDelta.RowState.from(
+                    isSelected: item.isSelected,
+                    baselineSelected: item.baselineSelected
+                )
                 let marker = item.isSelected
                     ? "\(green)\u{25CF}\(reset)"
                     : "\(dim)\u{25CB}\(reset)"
                 let pointer = isCursor ? "\(cyan)\u{276F}\(reset)" : " "
                 let nameStyle = isCursor ? "\(bold)\(cyan)\(item.name)\(reset)" : "\(bold)\(item.name)\(reset)"
-                output += "  \(pointer) \(marker) \(nameStyle)\n"
+                let tag = group.showsDelta
+                    ? PickerDelta.tagString(state: state, isCursor: isCursor, style: style)
+                    : ""
+                output += "  \(pointer) \(marker) \(nameStyle)\(tag)\n"
                 output += "\(dim)\(wordWrap(item.description, indent: "      ", columns: columns))\(reset)\n"
+
+                if group.showsDelta {
+                    switch state {
+                    case .newInstall: additions += 1
+                    case .installedRemoved: removals += 1
+                    case .installedKept: unchanged += 1
+                    case .notInstalled: break
+                    }
+                }
+                if isCursor, group.showsDelta {
+                    cursorRowState = state
+                }
                 flatIndex += 1
             }
         }
@@ -540,7 +565,14 @@ struct CLIOutput {
         }
 
         output += "\n"
-        output += "  \(dim)\u{2191}/\u{2193} Move \u{00B7} Space Toggle \u{00B7} Enter Confirm\(reset)\n"
+        if let cursorRowState {
+            let verb = PickerDelta.footerVerb(state: cursorRowState)
+            output += "  \(dim)\u{2191}/\u{2193} Move \u{00B7} \(verb) \u{00B7} Enter to apply\(reset)\n"
+            let counts = PickerDelta.DeltaCounts(additions: additions, removals: removals, unchanged: unchanged)
+            output += "  \(PickerDelta.counterString(counts: counts, style: style))\n"
+        } else {
+            output += "  \(dim)\u{2191}/\u{2193} Move \u{00B7} Space Toggle \u{00B7} Enter Confirm\(reset)\n"
+        }
         return output
     }
 
@@ -722,6 +754,7 @@ struct SelectableItem {
     let name: String
     let description: String
     var isSelected: Bool
+    var baselineSelected: Bool = false
 }
 
 struct RequiredItem {
@@ -732,6 +765,7 @@ struct SelectableGroup {
     let title: String
     var items: [SelectableItem]
     let requiredItems: [RequiredItem]
+    var showsDelta: Bool = false
 }
 
 // MARK: - Multi-Select Parser
@@ -755,5 +789,107 @@ enum MultiSelectParser {
             .compactMap { Int($0) }
         guard !numbers.isEmpty else { return .confirm }
         return .toggle(numbers)
+    }
+}
+
+// MARK: - ANSI Style
+
+/// Shared ANSI SGR codes used by rendering helpers that can't reach `CLIOutput`'s
+/// private computed color properties. Callers pass `enabled: false` in tests and
+/// non-TTY contexts to get plain text.
+/// Note: combined forms like `dimRed` use single SGR sequences (`\u{1B}[2;31m`);
+/// stacking two separate SGRs would reset and cancel the dim attribute.
+struct ANSIStyle {
+    let enabled: Bool
+
+    var reset: String {
+        enabled ? "\u{1B}[0m" : ""
+    }
+
+    var dim: String {
+        enabled ? "\u{1B}[2m" : ""
+    }
+
+    var red: String {
+        enabled ? "\u{1B}[0;31m" : ""
+    }
+
+    var green: String {
+        enabled ? "\u{1B}[0;32m" : ""
+    }
+
+    var yellow: String {
+        enabled ? "\u{1B}[1;33m" : ""
+    }
+
+    var dimRed: String {
+        enabled ? "\u{1B}[2;31m" : ""
+    }
+
+    var dimYellow: String {
+        enabled ? "\u{1B}[2;33m" : ""
+    }
+}
+
+// MARK: - Picker Delta Rendering
+
+/// Pure helpers that render delta-aware picker affordances (tags + footer verbs).
+/// The picker compares `isSelected` (user's current toggle) against `baselineSelected`
+/// (previously-configured state) to teach the convergent semantics of `mcs sync`.
+enum PickerDelta {
+    enum RowState {
+        case installedKept
+        case installedRemoved
+        case newInstall
+        case notInstalled
+
+        static func from(isSelected: Bool, baselineSelected: Bool) -> RowState {
+            switch (isSelected, baselineSelected) {
+            case (true, true): .installedKept
+            case (false, true): .installedRemoved
+            case (true, false): .newInstall
+            case (false, false): .notInstalled
+            }
+        }
+    }
+
+    struct DeltaCounts {
+        let additions: Int
+        let removals: Int
+        let unchanged: Int
+    }
+
+    static func tagString(state: RowState, isCursor: Bool, style: ANSIStyle) -> String {
+        let pad = "  "
+        let red = isCursor ? style.red : style.dimRed
+        let yellow = isCursor ? style.yellow : style.dimYellow
+
+        switch state {
+        case .installedKept:
+            return isCursor ? "\(pad)\(style.dim)[installed · uncheck to remove]\(style.reset)" : ""
+        case .notInstalled:
+            return isCursor ? "\(pad)\(style.dim)[not installed]\(style.reset)" : ""
+        case .installedRemoved:
+            return "\(pad)\(red)[installed · WILL REMOVE]\(style.reset)"
+        case .newInstall:
+            return "\(pad)\(yellow)[new · will install]\(style.reset)"
+        }
+    }
+
+    static func footerVerb(state: RowState) -> String {
+        switch state {
+        case .installedKept: "Space to remove"
+        case .installedRemoved: "Space to keep installed"
+        case .newInstall: "Space to cancel install"
+        case .notInstalled: "Space to install"
+        }
+    }
+
+    static func counterString(counts: DeltaCounts, style: ANSIStyle) -> String {
+        let addPart = "\(style.green)+\(counts.additions) to add\(style.reset)"
+        let removePart = "\(style.red)-\(counts.removals) to remove\(style.reset)"
+        let keepPart = "\(style.dim)\(counts.unchanged) unchanged\(style.reset)"
+        let sep = "\(style.dim)·\(style.reset)"
+        return "\(addPart) \(sep) \(removePart) \(sep) \(keepPart)"
     }
 }

--- a/Sources/mcs/Core/CLIOutput.swift
+++ b/Sources/mcs/Core/CLIOutput.swift
@@ -4,6 +4,7 @@ import Foundation
 struct CLIOutput {
     let colorsEnabled: Bool
     let isInteractiveTerminal: Bool
+    let style: ANSIStyle
 
     init(colorsEnabled: Bool? = nil) {
         if let explicit = colorsEnabled {
@@ -12,40 +13,41 @@ struct CLIOutput {
             self.colorsEnabled = isatty(STDOUT_FILENO) != 0
         }
         isInteractiveTerminal = self.colorsEnabled && isatty(STDIN_FILENO) != 0
+        style = ANSIStyle(enabled: self.colorsEnabled)
     }
 
-    // MARK: - ANSI Codes
+    // MARK: - ANSI Codes (delegate to `style`)
 
     private var red: String {
-        colorsEnabled ? "\u{1B}[0;31m" : ""
+        style.red
     }
 
     private var green: String {
-        colorsEnabled ? "\u{1B}[0;32m" : ""
+        style.green
     }
 
     private var yellow: String {
-        colorsEnabled ? "\u{1B}[1;33m" : ""
+        style.yellow
     }
 
     private var blue: String {
-        colorsEnabled ? "\u{1B}[0;34m" : ""
+        style.blue
     }
 
     private var cyan: String {
-        colorsEnabled ? "\u{1B}[0;36m" : ""
+        style.cyan
     }
 
     private var bold: String {
-        colorsEnabled ? "\u{1B}[1m" : ""
+        style.bold
     }
 
     private var dim: String {
-        colorsEnabled ? "\u{1B}[2m" : ""
+        style.dim
     }
 
     private var reset: String {
-        colorsEnabled ? "\u{1B}[0m" : ""
+        style.reset
     }
 
     // MARK: - Terminal Helpers
@@ -512,7 +514,6 @@ struct CLIOutput {
         columns: Int
     ) -> String {
         var output = ""
-        let style = ANSIStyle(enabled: colorsEnabled)
 
         var flatIndex = 0
         var cursorRowState: PickerDelta.RowState?
@@ -568,8 +569,7 @@ struct CLIOutput {
         if let cursorRowState {
             let verb = PickerDelta.footerVerb(state: cursorRowState)
             output += "  \(dim)\u{2191}/\u{2193} Move \u{00B7} \(verb) \u{00B7} Enter to apply\(reset)\n"
-            let counts = PickerDelta.DeltaCounts(additions: additions, removals: removals, unchanged: unchanged)
-            output += "  \(PickerDelta.counterString(counts: counts, style: style))\n"
+            output += "  \(PickerDelta.counterString(additions: additions, removals: removals, unchanged: unchanged, style: style))\n"
         } else {
             output += "  \(dim)\u{2191}/\u{2193} Move \u{00B7} Space Toggle \u{00B7} Enter Confirm\(reset)\n"
         }
@@ -754,6 +754,8 @@ struct SelectableItem {
     let name: String
     let description: String
     var isSelected: Bool
+    /// Only meaningful when the enclosing `SelectableGroup.showsDelta == true`;
+    /// otherwise ignored by the renderer.
     var baselineSelected: Bool = false
 }
 
@@ -765,6 +767,9 @@ struct SelectableGroup {
     let title: String
     var items: [SelectableItem]
     let requiredItems: [RequiredItem]
+    /// When true, items' `baselineSelected` drives delta-tag rendering and a
+    /// dynamic footer. Callers must populate `baselineSelected` on every item
+    /// or the renderer will treat pre-installed packs as brand-new.
     var showsDelta: Bool = false
 }
 
@@ -794,16 +799,17 @@ enum MultiSelectParser {
 
 // MARK: - ANSI Style
 
-/// Shared ANSI SGR codes used by rendering helpers that can't reach `CLIOutput`'s
-/// private computed color properties. Callers pass `enabled: false` in tests and
-/// non-TTY contexts to get plain text.
-/// Note: combined forms like `dimRed` use single SGR sequences (`\u{1B}[2;31m`);
+/// Combined forms like `dimRed` use single SGR sequences (`\u{1B}[2;31m`);
 /// stacking two separate SGRs would reset and cancel the dim attribute.
 struct ANSIStyle {
     let enabled: Bool
 
     var reset: String {
         enabled ? "\u{1B}[0m" : ""
+    }
+
+    var bold: String {
+        enabled ? "\u{1B}[1m" : ""
     }
 
     var dim: String {
@@ -822,6 +828,14 @@ struct ANSIStyle {
         enabled ? "\u{1B}[1;33m" : ""
     }
 
+    var blue: String {
+        enabled ? "\u{1B}[0;34m" : ""
+    }
+
+    var cyan: String {
+        enabled ? "\u{1B}[0;36m" : ""
+    }
+
     var dimRed: String {
         enabled ? "\u{1B}[2;31m" : ""
     }
@@ -833,9 +847,6 @@ struct ANSIStyle {
 
 // MARK: - Picker Delta Rendering
 
-/// Pure helpers that render delta-aware picker affordances (tags + footer verbs).
-/// The picker compares `isSelected` (user's current toggle) against `baselineSelected`
-/// (previously-configured state) to teach the convergent semantics of `mcs sync`.
 enum PickerDelta {
     enum RowState {
         case installedKept
@@ -851,12 +862,6 @@ enum PickerDelta {
             case (false, false): .notInstalled
             }
         }
-    }
-
-    struct DeltaCounts {
-        let additions: Int
-        let removals: Int
-        let unchanged: Int
     }
 
     static func tagString(state: RowState, isCursor: Bool, style: ANSIStyle) -> String {
@@ -885,10 +890,10 @@ enum PickerDelta {
         }
     }
 
-    static func counterString(counts: DeltaCounts, style: ANSIStyle) -> String {
-        let addPart = "\(style.green)+\(counts.additions) to add\(style.reset)"
-        let removePart = "\(style.red)-\(counts.removals) to remove\(style.reset)"
-        let keepPart = "\(style.dim)\(counts.unchanged) unchanged\(style.reset)"
+    static func counterString(additions: Int, removals: Int, unchanged: Int, style: ANSIStyle) -> String {
+        let addPart = "\(style.green)+\(additions) to add\(style.reset)"
+        let removePart = "\(style.red)-\(removals) to remove\(style.reset)"
+        let keepPart = "\(style.dim)\(unchanged) unchanged\(style.reset)"
         let sep = "\(style.dim)·\(style.reset)"
         return "\(addPart) \(sep) \(removePart) \(sep) \(keepPart)"
     }

--- a/Sources/mcs/Sync/Configurator.swift
+++ b/Sources/mcs/Sync/Configurator.swift
@@ -57,20 +57,28 @@ struct Configurator {
         let previousPacks = previousState.configuredPacks
 
         let items = packs.enumerated().map { index, pack in
-            SelectableItem(
+            let installed = previousPacks.contains(pack.identifier)
+            return SelectableItem(
                 number: index + 1,
                 name: pack.displayName,
                 description: pack.description,
-                isSelected: previousPacks.contains(pack.identifier)
+                isSelected: installed,
+                baselineSelected: installed
             )
         }
 
-        let groupTitle = scope.isGlobalScope ? "Tech Packs (Global)" : "Tech Packs"
+        let groupTitle = scope.isGlobalScope
+            ? "Packs to install globally (selected = installed after sync)"
+            : "Packs to install in this project (selected = installed after sync)"
         var groups = [SelectableGroup(
             title: groupTitle,
             items: items,
-            requiredItems: []
+            requiredItems: [],
+            showsDelta: true
         )]
+
+        output.plain("")
+        output.plain("  Selected packs stay or get added. Deselected packs are removed.")
 
         let selectedNumbers = output.multiSelect(groups: &groups)
 
@@ -82,6 +90,24 @@ struct Configurator {
             output.plain("")
             output.info("No packs selected. Nothing to configure.")
             return
+        }
+
+        if !dryRun {
+            let selectedIDs = Set(selectedPacks.map(\.identifier))
+            let summary = SyncDeltaSummary(previous: previousPacks, selected: selectedIDs)
+            if summary.hasRemovals {
+                output.plain("")
+                output.header("Review changes")
+                output.plain(SyncDeltaSummary.renderReviewBlock(summary, style: ANSIStyle(enabled: output.colorsEnabled)))
+                output.plain("")
+                // 'n' during the picker binds to "select none" (CLIOutput.swift interactiveMultiSelect);
+                // a user who hits 'n' thinking it means "cancel" lands on this confirmation with a full
+                // removal summary and default: false — Enter aborts safely.
+                guard output.askYesNo("Apply these changes?", default: false) else {
+                    output.info("Sync cancelled.")
+                    return
+                }
+            }
         }
 
         var excludedComponents: [String: Set<String>] = [:]
@@ -96,7 +122,9 @@ struct Configurator {
         if dryRun {
             try self.dryRun(packs: selectedPacks)
         } else {
-            try configure(packs: selectedPacks, excludedComponents: excludedComponents)
+            // Interactive flow owns the removal confirmation via the "Review changes" screen above,
+            // so suppress the duplicate askYesNo inside configure() (gated by confirmRemovals: true).
+            try configure(packs: selectedPacks, confirmRemovals: false, excludedComponents: excludedComponents)
 
             output.header("Done")
             output.info("Run 'mcs doctor' to verify configuration")

--- a/Sources/mcs/Sync/Configurator.swift
+++ b/Sources/mcs/Sync/Configurator.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import Foundation
 
 /// Unified configuration engine for both project-scoped and global-scoped sync.
@@ -39,6 +40,15 @@ struct Configurator {
     ///
     /// - Parameter customize: When `true`, present per-pack component multi-select after pack selection.
     func interactiveConfigure(dryRun: Bool = false, customize: Bool = false) throws {
+        // The picker and confirmation require a TTY. Without it, piped/closed stdin
+        // silently returns the default (false on confirm), which would look like a
+        // successful sync but apply nothing. Fail loudly and point at non-interactive flags.
+        guard output.isInteractiveTerminal else {
+            output.error("Interactive sync requires a terminal.")
+            output.plain("  Use --pack <name> (repeatable) or --all for non-interactive sync.")
+            throw ExitCode.failure
+        }
+
         output.header("Sync \(scope.label)")
         output.plain("")
         if scope.isGlobalScope {
@@ -98,12 +108,15 @@ struct Configurator {
             if summary.hasRemovals {
                 output.plain("")
                 output.header("Review changes")
-                output.plain(SyncDeltaSummary.renderReviewBlock(summary, style: ANSIStyle(enabled: output.colorsEnabled)))
+                output.plain(summary.renderReviewBlock(style: output.style))
                 output.plain("")
-                // 'n' during the picker binds to "select none" (CLIOutput.swift interactiveMultiSelect);
-                // a user who hits 'n' thinking it means "cancel" lands on this confirmation with a full
-                // removal summary and default: false — Enter aborts safely.
-                guard output.askYesNo("Apply these changes?", default: false) else {
+                if summary.isFullWipe {
+                    output.warn("This will remove ALL configured packs from this \(scope.label).")
+                }
+                // 'n' in the picker binds to "select none"; default: false lets a user who hit it
+                // thinking "cancel" still abort safely from the confirmation.
+                let prompt = summary.isFullWipe ? "Remove all configured packs?" : "Apply these changes?"
+                guard output.askYesNo(prompt, default: false) else {
                     output.info("Sync cancelled.")
                     return
                 }
@@ -122,8 +135,7 @@ struct Configurator {
         if dryRun {
             try self.dryRun(packs: selectedPacks)
         } else {
-            // Interactive flow owns the removal confirmation via the "Review changes" screen above,
-            // so suppress the duplicate askYesNo inside configure() (gated by confirmRemovals: true).
+            // Interactive flow already confirmed via the "Review changes" screen above.
             try configure(packs: selectedPacks, confirmRemovals: false, excludedComponents: excludedComponents)
 
             output.header("Done")

--- a/Sources/mcs/Sync/Configurator.swift
+++ b/Sources/mcs/Sync/Configurator.swift
@@ -40,10 +40,12 @@ struct Configurator {
     ///
     /// - Parameter customize: When `true`, present per-pack component multi-select after pack selection.
     func interactiveConfigure(dryRun: Bool = false, customize: Bool = false) throws {
-        // The picker and confirmation require a TTY. Without it, piped/closed stdin
-        // silently returns the default (false on confirm), which would look like a
-        // successful sync but apply nothing. Fail loudly and point at non-interactive flags.
-        guard output.isInteractiveTerminal else {
+        // Piped/closed stdin means the confirmation prompt silently returns its default,
+        // which would look like a successful sync while applying nothing. Fail loudly
+        // and point at non-interactive flags. Note: `hasInteractiveStdin` (not
+        // `isInteractiveTerminal`) — piped stdout with TTY stdin is still a valid
+        // flow that drops into the fallback picker/prompt.
+        guard output.hasInteractiveStdin else {
             output.error("Interactive sync requires a terminal.")
             output.plain("  Use --pack <name> (repeatable) or --all for non-interactive sync.")
             throw ExitCode.failure

--- a/Sources/mcs/Sync/SyncDeltaSummary.swift
+++ b/Sources/mcs/Sync/SyncDeltaSummary.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// `additions`, `removals`, `keeps` form a disjoint partition of `previous ∪ selected` —
+/// the three-way split is the whole reason this type exists.
 struct SyncDeltaSummary {
     let additions: [String]
     let removals: [String]
@@ -19,18 +21,22 @@ struct SyncDeltaSummary {
         !additions.isEmpty || !removals.isEmpty
     }
 
-    /// Accepts `ANSIStyle` (not a bare `Bool`) so tests can assert plain text
-    /// via `ANSIStyle(enabled: false)` without leaking hardcoded escape codes.
-    static func renderReviewBlock(_ summary: SyncDeltaSummary, style: ANSIStyle) -> String {
+    /// True when the delta is "remove every previously configured pack with nothing to keep or add."
+    /// Callers use this to render a stronger warning before confirming a full wipe.
+    var isFullWipe: Bool {
+        !removals.isEmpty && additions.isEmpty && keeps.isEmpty
+    }
+
+    func renderReviewBlock(style: ANSIStyle) -> String {
         var lines: [String] = []
-        if !summary.additions.isEmpty {
-            lines.append("  \(style.green)+ add:\(style.reset)      \(summary.additions.joined(separator: ", "))")
+        if !additions.isEmpty {
+            lines.append("  \(style.green)+ add:\(style.reset)      \(additions.joined(separator: ", "))")
         }
-        if !summary.removals.isEmpty {
-            lines.append("  \(style.red)- remove:\(style.reset)   \(summary.removals.joined(separator: ", "))")
+        if !removals.isEmpty {
+            lines.append("  \(style.red)- remove:\(style.reset)   \(removals.joined(separator: ", "))")
         }
-        if !summary.keeps.isEmpty {
-            lines.append("  \(style.dim)= keep:\(style.reset)     \(summary.keeps.joined(separator: ", "))")
+        if !keeps.isEmpty {
+            lines.append("  \(style.dim)= keep:\(style.reset)     \(keeps.joined(separator: ", "))")
         }
         return lines.joined(separator: "\n")
     }

--- a/Sources/mcs/Sync/SyncDeltaSummary.swift
+++ b/Sources/mcs/Sync/SyncDeltaSummary.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct SyncDeltaSummary {
+    let additions: [String]
+    let removals: [String]
+    let keeps: [String]
+
+    init(previous: Set<String>, selected: Set<String>) {
+        additions = selected.subtracting(previous).sorted()
+        removals = previous.subtracting(selected).sorted()
+        keeps = previous.intersection(selected).sorted()
+    }
+
+    var hasRemovals: Bool {
+        !removals.isEmpty
+    }
+
+    var hasAnyChange: Bool {
+        !additions.isEmpty || !removals.isEmpty
+    }
+
+    /// Accepts `ANSIStyle` (not a bare `Bool`) so tests can assert plain text
+    /// via `ANSIStyle(enabled: false)` without leaking hardcoded escape codes.
+    static func renderReviewBlock(_ summary: SyncDeltaSummary, style: ANSIStyle) -> String {
+        var lines: [String] = []
+        if !summary.additions.isEmpty {
+            lines.append("  \(style.green)+ add:\(style.reset)      \(summary.additions.joined(separator: ", "))")
+        }
+        if !summary.removals.isEmpty {
+            lines.append("  \(style.red)- remove:\(style.reset)   \(summary.removals.joined(separator: ", "))")
+        }
+        if !summary.keeps.isEmpty {
+            lines.append("  \(style.dim)= keep:\(style.reset)     \(summary.keeps.joined(separator: ", "))")
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Tests/MCSTests/ANSIStyleTests.swift
+++ b/Tests/MCSTests/ANSIStyleTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+@testable import mcs
+import Testing
+
+struct ANSIStyleTests {
+    @Test("Enabled style emits SGR sequences")
+    func enabled() {
+        let style = ANSIStyle(enabled: true)
+        #expect(style.reset == "\u{1B}[0m")
+        #expect(style.dim == "\u{1B}[2m")
+        #expect(style.red == "\u{1B}[0;31m")
+        #expect(style.green == "\u{1B}[0;32m")
+        #expect(style.yellow == "\u{1B}[1;33m")
+    }
+
+    @Test("Disabled style returns empty strings so tests can assert plain text")
+    func disabled() {
+        let style = ANSIStyle(enabled: false)
+        #expect(style.reset.isEmpty)
+        #expect(style.dim.isEmpty)
+        #expect(style.red.isEmpty)
+        #expect(style.green.isEmpty)
+        #expect(style.yellow.isEmpty)
+        #expect(style.dimRed.isEmpty)
+        #expect(style.dimYellow.isEmpty)
+    }
+
+    @Test("Combined forms use single SGR sequences (stacking two SGRs would cancel dim)")
+    func combinedForms() {
+        let style = ANSIStyle(enabled: true)
+        #expect(style.dimRed == "\u{1B}[2;31m")
+        #expect(style.dimYellow == "\u{1B}[2;33m")
+    }
+}

--- a/Tests/MCSTests/PickerDeltaTests.swift
+++ b/Tests/MCSTests/PickerDeltaTests.swift
@@ -92,19 +92,15 @@ struct PickerDeltaTests {
 
     // MARK: - counterString
 
-    @Test("counterString formats all three counts")
+    @Test("counterString plain output matches golden layout")
     func counterFormat() {
-        let counts = PickerDelta.DeltaCounts(additions: 2, removals: 1, unchanged: 3)
-        let rendered = PickerDelta.counterString(counts: counts, style: plain)
-        #expect(rendered.contains("+2 to add"))
-        #expect(rendered.contains("-1 to remove"))
-        #expect(rendered.contains("3 unchanged"))
+        let rendered = PickerDelta.counterString(additions: 2, removals: 1, unchanged: 3, style: plain)
+        #expect(rendered == "+2 to add · -1 to remove · 3 unchanged")
     }
 
     @Test("counterString emits ANSI when colors enabled")
     func counterColors() {
-        let counts = PickerDelta.DeltaCounts(additions: 1, removals: 1, unchanged: 1)
-        let rendered = PickerDelta.counterString(counts: counts, style: colored)
+        let rendered = PickerDelta.counterString(additions: 1, removals: 1, unchanged: 1, style: colored)
         #expect(rendered.contains("\u{1B}[0;32m"))
         #expect(rendered.contains("\u{1B}[0;31m"))
         #expect(rendered.contains("\u{1B}[2m"))

--- a/Tests/MCSTests/PickerDeltaTests.swift
+++ b/Tests/MCSTests/PickerDeltaTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+@testable import mcs
+import Testing
+
+struct PickerDeltaTests {
+    // MARK: - RowState
+
+    private let plain = ANSIStyle(enabled: false)
+    private let colored = ANSIStyle(enabled: true)
+
+    @Test("RowState classifies all four (isSelected, baselineSelected) combinations")
+    func rowStateMatrix() {
+        #expect(PickerDelta.RowState.from(isSelected: true, baselineSelected: true) == .installedKept)
+        #expect(PickerDelta.RowState.from(isSelected: false, baselineSelected: true) == .installedRemoved)
+        #expect(PickerDelta.RowState.from(isSelected: true, baselineSelected: false) == .newInstall)
+        #expect(PickerDelta.RowState.from(isSelected: false, baselineSelected: false) == .notInstalled)
+    }
+
+    // MARK: - tagString
+
+    @Test("installedKept renders teaching tag only under cursor")
+    func installedKeptTag() {
+        let cursor = PickerDelta.tagString(state: .installedKept, isCursor: true, style: plain)
+        let offCursor = PickerDelta.tagString(state: .installedKept, isCursor: false, style: plain)
+
+        #expect(cursor.contains("installed · uncheck to remove"))
+        #expect(offCursor.isEmpty)
+    }
+
+    @Test("notInstalled renders plain tag only under cursor")
+    func notInstalledTag() {
+        let cursor = PickerDelta.tagString(state: .notInstalled, isCursor: true, style: plain)
+        let offCursor = PickerDelta.tagString(state: .notInstalled, isCursor: false, style: plain)
+
+        #expect(cursor.contains("not installed"))
+        #expect(offCursor.isEmpty)
+    }
+
+    @Test("installedRemoved renders tag whether or not cursor is on the row")
+    func installedRemovedTagAlwaysShown() {
+        let cursor = PickerDelta.tagString(state: .installedRemoved, isCursor: true, style: plain)
+        let offCursor = PickerDelta.tagString(state: .installedRemoved, isCursor: false, style: plain)
+
+        #expect(cursor.contains("installed · WILL REMOVE"))
+        #expect(offCursor.contains("installed · WILL REMOVE"))
+    }
+
+    @Test("newInstall renders tag whether or not cursor is on the row")
+    func newInstallTagAlwaysShown() {
+        let cursor = PickerDelta.tagString(state: .newInstall, isCursor: true, style: plain)
+        let offCursor = PickerDelta.tagString(state: .newInstall, isCursor: false, style: plain)
+
+        #expect(cursor.contains("new · will install"))
+        #expect(offCursor.contains("new · will install"))
+    }
+
+    @Test("Cursor installedRemoved uses bright red, off-cursor uses dim red")
+    func installedRemovedColors() {
+        let cursor = PickerDelta.tagString(state: .installedRemoved, isCursor: true, style: colored)
+        let offCursor = PickerDelta.tagString(state: .installedRemoved, isCursor: false, style: colored)
+
+        #expect(cursor.contains("\u{1B}[0;31m"))
+        #expect(offCursor.contains("\u{1B}[2;31m"))
+    }
+
+    @Test("Cursor newInstall uses bright yellow, off-cursor uses dim yellow")
+    func newInstallColors() {
+        let cursor = PickerDelta.tagString(state: .newInstall, isCursor: true, style: colored)
+        let offCursor = PickerDelta.tagString(state: .newInstall, isCursor: false, style: colored)
+
+        #expect(cursor.contains("\u{1B}[1;33m"))
+        #expect(offCursor.contains("\u{1B}[2;33m"))
+    }
+
+    @Test("Plain style produces no ANSI codes")
+    func tagsPlainWhenColorsOff() {
+        for state in [PickerDelta.RowState.installedKept, .installedRemoved, .newInstall, .notInstalled] {
+            let tag = PickerDelta.tagString(state: state, isCursor: true, style: plain)
+            #expect(!tag.contains("\u{1B}["), "State \(state) leaked ANSI")
+        }
+    }
+
+    // MARK: - footerVerb
+
+    @Test("footerVerb matches each row state's action")
+    func footerVerbs() {
+        #expect(PickerDelta.footerVerb(state: .installedKept) == "Space to remove")
+        #expect(PickerDelta.footerVerb(state: .installedRemoved) == "Space to keep installed")
+        #expect(PickerDelta.footerVerb(state: .newInstall) == "Space to cancel install")
+        #expect(PickerDelta.footerVerb(state: .notInstalled) == "Space to install")
+    }
+
+    // MARK: - counterString
+
+    @Test("counterString formats all three counts")
+    func counterFormat() {
+        let counts = PickerDelta.DeltaCounts(additions: 2, removals: 1, unchanged: 3)
+        let rendered = PickerDelta.counterString(counts: counts, style: plain)
+        #expect(rendered.contains("+2 to add"))
+        #expect(rendered.contains("-1 to remove"))
+        #expect(rendered.contains("3 unchanged"))
+    }
+
+    @Test("counterString emits ANSI when colors enabled")
+    func counterColors() {
+        let counts = PickerDelta.DeltaCounts(additions: 1, removals: 1, unchanged: 1)
+        let rendered = PickerDelta.counterString(counts: counts, style: colored)
+        #expect(rendered.contains("\u{1B}[0;32m"))
+        #expect(rendered.contains("\u{1B}[0;31m"))
+        #expect(rendered.contains("\u{1B}[2m"))
+    }
+}

--- a/Tests/MCSTests/SyncDeltaSummaryTests.swift
+++ b/Tests/MCSTests/SyncDeltaSummaryTests.swift
@@ -71,43 +71,54 @@ struct SyncDeltaSummaryTests {
         #expect(summary.removals == ["mike"])
     }
 
-    @Test("renderReviewBlock with plain style contains all pack names")
-    func renderPlain() {
+    @Test("renderReviewBlock plain output matches golden layout")
+    func renderPlainGolden() {
         let summary = SyncDeltaSummary(
             previous: ["android", "swift"],
             selected: ["swift", "kotlin"]
         )
-        let block = SyncDeltaSummary.renderReviewBlock(summary, style: ANSIStyle(enabled: false))
-
-        #expect(block.contains("+ add:"))
-        #expect(block.contains("- remove:"))
-        #expect(block.contains("= keep:"))
-        #expect(block.contains("kotlin"))
-        #expect(block.contains("android"))
-        #expect(block.contains("swift"))
-        #expect(!block.contains("\u{1B}["))
+        let block = summary.renderReviewBlock(style: ANSIStyle(enabled: false))
+        let expected = """
+          + add:      kotlin
+          - remove:   android
+          = keep:     swift
+        """
+        #expect(block == expected)
     }
 
-    @Test("renderReviewBlock with colored style emits ANSI codes")
+    @Test("renderReviewBlock colored output emits green, red, AND dim")
     func renderColored() {
         let summary = SyncDeltaSummary(
-            previous: ["android"],
-            selected: ["kotlin"]
+            previous: ["android", "shared"],
+            selected: ["kotlin", "shared"]
         )
-        let block = SyncDeltaSummary.renderReviewBlock(summary, style: ANSIStyle(enabled: true))
+        let block = summary.renderReviewBlock(style: ANSIStyle(enabled: true))
 
         #expect(block.contains("\u{1B}[0;32m"))
         #expect(block.contains("\u{1B}[0;31m"))
+        #expect(block.contains("\u{1B}[2m"))
         #expect(block.contains("\u{1B}[0m"))
     }
 
     @Test("renderReviewBlock omits sections that are empty")
     func renderOmitsEmpty() {
         let summary = SyncDeltaSummary(previous: [], selected: ["ios"])
-        let block = SyncDeltaSummary.renderReviewBlock(summary, style: ANSIStyle(enabled: false))
+        let block = summary.renderReviewBlock(style: ANSIStyle(enabled: false))
 
         #expect(block.contains("+ add:"))
         #expect(!block.contains("- remove:"))
         #expect(!block.contains("= keep:"))
+    }
+
+    @Test("isFullWipe true when removing every previous pack with nothing to keep or add")
+    func fullWipe() {
+        let wipe = SyncDeltaSummary(previous: ["ios", "swift"], selected: [])
+        #expect(wipe.isFullWipe)
+
+        let partialRemoval = SyncDeltaSummary(previous: ["ios", "swift"], selected: ["ios"])
+        #expect(!partialRemoval.isFullWipe)
+
+        let additionsOnly = SyncDeltaSummary(previous: [], selected: ["ios"])
+        #expect(!additionsOnly.isFullWipe)
     }
 }

--- a/Tests/MCSTests/SyncDeltaSummaryTests.swift
+++ b/Tests/MCSTests/SyncDeltaSummaryTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+@testable import mcs
+import Testing
+
+struct SyncDeltaSummaryTests {
+    @Test("Buckets additions, removals, and keeps from arbitrary sets")
+    func buckets() {
+        let summary = SyncDeltaSummary(
+            previous: ["ios", "swift", "android"],
+            selected: ["ios", "swift", "kotlin"]
+        )
+
+        #expect(summary.additions == ["kotlin"])
+        #expect(summary.removals == ["android"])
+        #expect(summary.keeps == ["ios", "swift"])
+    }
+
+    @Test("Empty previous means everything is an addition")
+    func allAdditions() {
+        let summary = SyncDeltaSummary(
+            previous: [],
+            selected: ["ios", "swift"]
+        )
+
+        #expect(summary.additions == ["ios", "swift"])
+        #expect(summary.removals.isEmpty)
+        #expect(summary.keeps.isEmpty)
+    }
+
+    @Test("Empty selected means everything is a removal")
+    func allRemovals() {
+        let summary = SyncDeltaSummary(
+            previous: ["ios", "swift"],
+            selected: []
+        )
+
+        #expect(summary.additions.isEmpty)
+        #expect(summary.removals == ["ios", "swift"])
+        #expect(summary.keeps.isEmpty)
+    }
+
+    @Test("Identical sets produce keeps only")
+    func noChanges() {
+        let summary = SyncDeltaSummary(
+            previous: ["ios", "swift"],
+            selected: ["ios", "swift"]
+        )
+
+        #expect(summary.additions.isEmpty)
+        #expect(summary.removals.isEmpty)
+        #expect(summary.keeps == ["ios", "swift"])
+        #expect(summary.hasAnyChange == false)
+        #expect(summary.hasRemovals == false)
+    }
+
+    @Test("hasRemovals reflects removal presence")
+    func hasRemovalsFlag() {
+        let withRemovals = SyncDeltaSummary(previous: ["a"], selected: [])
+        let withoutRemovals = SyncDeltaSummary(previous: [], selected: ["a"])
+        #expect(withRemovals.hasRemovals)
+        #expect(!withoutRemovals.hasRemovals)
+    }
+
+    @Test("Sorting is deterministic")
+    func sorting() {
+        let summary = SyncDeltaSummary(
+            previous: ["zebra", "alpha", "mike"],
+            selected: ["zebra", "alpha"]
+        )
+        #expect(summary.keeps == ["alpha", "zebra"])
+        #expect(summary.removals == ["mike"])
+    }
+
+    @Test("renderReviewBlock with plain style contains all pack names")
+    func renderPlain() {
+        let summary = SyncDeltaSummary(
+            previous: ["android", "swift"],
+            selected: ["swift", "kotlin"]
+        )
+        let block = SyncDeltaSummary.renderReviewBlock(summary, style: ANSIStyle(enabled: false))
+
+        #expect(block.contains("+ add:"))
+        #expect(block.contains("- remove:"))
+        #expect(block.contains("= keep:"))
+        #expect(block.contains("kotlin"))
+        #expect(block.contains("android"))
+        #expect(block.contains("swift"))
+        #expect(!block.contains("\u{1B}["))
+    }
+
+    @Test("renderReviewBlock with colored style emits ANSI codes")
+    func renderColored() {
+        let summary = SyncDeltaSummary(
+            previous: ["android"],
+            selected: ["kotlin"]
+        )
+        let block = SyncDeltaSummary.renderReviewBlock(summary, style: ANSIStyle(enabled: true))
+
+        #expect(block.contains("\u{1B}[0;32m"))
+        #expect(block.contains("\u{1B}[0;31m"))
+        #expect(block.contains("\u{1B}[0m"))
+    }
+
+    @Test("renderReviewBlock omits sections that are empty")
+    func renderOmitsEmpty() {
+        let summary = SyncDeltaSummary(previous: [], selected: ["ios"])
+        let block = SyncDeltaSummary.renderReviewBlock(summary, style: ANSIStyle(enabled: false))
+
+        #expect(block.contains("+ add:"))
+        #expect(!block.contains("- remove:"))
+        #expect(!block.contains("= keep:"))
+    }
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,6 +108,26 @@ claude plugin install <plugin-name>@<org>
 
 ## Project Configuration
 
+### Running `mcs sync` from `~/.claude` or `$HOME`
+
+**Symptom**: `mcs sync` prompts "Did you mean `mcs sync --global`?" or errors with a message about refusing to sync project scope inside the Claude home directory.
+
+`mcs sync` without `--global` treats the current directory as a project. Running it from `~/.claude` or `$HOME` would create `~/.claude/.claude/` and write project-scope tracking state on top of the global Claude install — a silent corruption that `mcs doctor` could not recognize afterwards. The guard catches the three common forms:
+
+- **Bare interactive** (`cd ~/.claude && mcs sync`) — prompts `y/N` to promote the run to `--global`.
+- **Non-interactive** (`mcs sync --pack foo` or `mcs sync --all`) — hard-errors, no prompt.
+- **`cd ~/.claude && mcs sync --global`** — silently redirected to `$HOME` and proceeds (no prompt, no error).
+
+**Fix**: Either answer `y` at the prompt, pass `--global` explicitly, or `cd` into an actual project directory first:
+
+```bash
+mcs sync --global              # explicit global sync, works from anywhere
+cd ~/Developer/my-project      # or move into the project, then:
+mcs sync
+```
+
+The guard is gated on `~/.claude.json` existing as a sibling, so it never triggers in test fixtures or fresh installs that haven't run `claude` yet.
+
 ### No packs registered
 
 **Symptom**: `mcs sync` shows "No packs registered."


### PR DESCRIPTION
## Summary

Resolves #328. The `mcs sync` interactive picker now teaches its convergent semantics on every keystroke: pre-installed packs carry a cursor-contextual tag, the footer verb changes with cursor position, a live `+/- to add/remove` counter aggregates across all items, and a review screen appears before any removals are committed. Together these signals address the two reported confusions — "picker looks read-only" and "I didn't realize deselecting removes the pack."

## Changes

- **Delta-aware picker rendering** (`CLIOutput.buildInteractiveListString`): new `PickerDelta` helper derives a 4-case `RowState` from `(isSelected, baselineSelected)`; cursor row shows `[installed · uncheck to remove]` / `[new · will install]` / `[installed · WILL REMOVE]` / `[not installed]`; off-cursor rows keep dimmed tags only when changed from baseline; footer swaps the static "Space Toggle" hint for a dynamic verb plus `+N to add · -M to remove · K unchanged`.
- **Review-changes confirmation** (`Configurator.interactiveConfigure`): after the picker, if any removals are selected, render the add/remove/keep summary and gate on `askYesNo("Apply these changes?", default: false)`. Skipped for `--dry-run` and additions-only flows. Passes `confirmRemovals: false` to `configure()` to suppress the now-duplicate internal prompt.
- **Header rewrite + new opt-in fields**: `"Tech Packs"` → `"Packs to install in this project (selected = installed after sync)"`. Adds `SelectableItem.baselineSelected` and `SelectableGroup.showsDelta` as opt-in defaults so `ExportCommand` and `ConfiguratorSupport.selectComponentExclusions` stay unchanged.
- **Pure, unit-tested primitives**: new `ANSIStyle` (`reset`/`dim`/`red`/`green`/`yellow`/`dimRed`/`dimYellow`) eliminates hand-rolled SGR duplication and bakes in the "dim+color" SGR gotcha; new `PickerDelta.DeltaCounts` struct collapses the counter signature; new `SyncDeltaSummary` provides the diff-and-render primitive used by the confirmation screen.
- **Tests**: three new suites (`ANSIStyleTests`, `PickerDeltaTests`, `SyncDeltaSummaryTests`) adding 20 tests; full suite runs 1025 tests green.

## Test plan

- [x] `swift test` passes locally (1025 tests, 119 suites)
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] `mcs sync` walkthrough with at least one installed + one not-installed pack — verify tags, dynamic footer verb, live counter, confirmation screen on removals (and its absence on additions-only), cancel path, `--dry-run` bypass
- [ ] `mcs sync --global` — same UX with globally-scoped header
- [ ] `mcs sync --pack foo` / `mcs sync --all` — non-interactive paths unaffected

<details>
<summary>Checklist for engine changes</summary>

- [x] Integration tests unchanged — the interactive picker was never test-covered; new pure helpers (`ANSIStyle`, `PickerDelta`, `SyncDeltaSummary`) are unit-tested instead
- [x] `CLAUDE.md` unchanged — existing guidance still applies; new architecture memory saved at `.claude/memories/decision_architecture_sync_picker_delta_implementation.md`

</details>