### PR TITLE
#334: Fix branch-ref freeze and stale update-check cache

### DIFF
--- a/Sources/mcs/Commands/PackCommand.swift
+++ b/Sources/mcs/Commands/PackCommand.swift
@@ -691,10 +691,6 @@ struct UpdatePack: LockedCommand {
                 ctx.output.error("Failed to save registry: \(error.localizedDescription)")
                 throw ExitCode.failure
             }
-            // Invalidate update check cache so the next hook re-checks
-            if !UpdateChecker.invalidateCache(environment: ctx.env) {
-                ctx.output.warn("Could not clear update check cache — next session may show stale update info")
-            }
             ctx.output.plain("")
             ctx.output.info("Run 'mcs sync' to apply updated pack components.")
         }

--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -153,7 +153,8 @@ struct UpdateChecker {
 
     /// Delete the cache file (e.g., after `mcs pack update`).
     /// Returns true if deleted or already absent; false on permission error.
-    @discardableResult
+    /// Callers must decide how to react to `false` — silently discarding it re-introduces
+    /// the "stale update banner" defect from issue #334.
     static func invalidateCache(environment: Environment) -> Bool {
         let fm = FileManager.default
         guard fm.fileExists(atPath: environment.updateCheckCacheFile.path) else { return true }

--- a/Sources/mcs/ExternalPack/PackFetcher.swift
+++ b/Sources/mcs/ExternalPack/PackFetcher.swift
@@ -61,6 +61,10 @@ struct PackFetcher {
 
     /// Update an existing pack checkout.
     /// Returns a `FetchResult` if updated, or `nil` if already at the latest commit.
+    ///
+    /// When `ref` is set, fetches that ref explicitly and resets to `FETCH_HEAD` — uniform for
+    /// branches and tags. A plain `checkout <branch>` would not advance the local branch past
+    /// whatever was captured at clone time, freezing branch-ref packs (see issue #334).
     func update(packPath: URL, ref: String?) throws -> FetchResult? {
         try ensureGitAvailable()
         if let ref { try validateRef(ref) }
@@ -68,47 +72,33 @@ struct PackFetcher {
         let beforeSHA = try currentCommit(at: packPath)
         let workDir = packPath.path
 
-        // Fetch latest from remote
+        let fetchArgs: [String]
+        let resetTarget: String
+        if let ref {
+            fetchArgs = ["fetch", "--depth", "1", "origin", ref]
+            resetTarget = "FETCH_HEAD"
+        } else {
+            fetchArgs = ["fetch", "--depth", "1", "origin"]
+            resetTarget = "origin/HEAD"
+        }
+
         let fetchResult = shell.run(
-            shell.environment.gitPath, arguments: ["fetch", "--depth", "1", "origin"],
+            shell.environment.gitPath, arguments: fetchArgs,
             workingDirectory: workDir
         )
         guard fetchResult.succeeded else {
+            if let ref {
+                throw PackFetchError.refNotFound(ref: ref, stderr: fetchResult.stderr)
+            }
             throw PackFetchError.fetchFailed(path: packPath.path, stderr: fetchResult.stderr)
         }
 
-        if let ref {
-            // Check out the specific ref
-            let checkoutResult = shell.run(
-                shell.environment.gitPath, arguments: ["checkout", ref],
-                workingDirectory: workDir
-            )
-            if !checkoutResult.succeeded {
-                // Try fetching the ref explicitly (e.g. a new tag)
-                let fetchTagResult = shell.run(
-                    shell.environment.gitPath, arguments: ["fetch", "--depth", "1", "origin", "tag", ref],
-                    workingDirectory: workDir
-                )
-                guard fetchTagResult.succeeded else {
-                    throw PackFetchError.refNotFound(ref: ref, stderr: checkoutResult.stderr)
-                }
-                let retryCheckout = shell.run(
-                    shell.environment.gitPath, arguments: ["checkout", ref],
-                    workingDirectory: workDir
-                )
-                guard retryCheckout.succeeded else {
-                    throw PackFetchError.refNotFound(ref: ref, stderr: retryCheckout.stderr)
-                }
-            }
-        } else {
-            // Tracking default branch — reset to remote HEAD
-            let resetResult = shell.run(
-                shell.environment.gitPath, arguments: ["reset", "--hard", "origin/HEAD"],
-                workingDirectory: workDir
-            )
-            guard resetResult.succeeded else {
-                throw PackFetchError.updateFailed(path: packPath.path, stderr: resetResult.stderr)
-            }
+        let resetResult = shell.run(
+            shell.environment.gitPath, arguments: ["reset", "--hard", resetTarget],
+            workingDirectory: workDir
+        )
+        guard resetResult.succeeded else {
+            throw PackFetchError.updateFailed(path: packPath.path, stderr: resetResult.stderr)
         }
 
         let afterSHA = try currentCommit(at: packPath)

--- a/Sources/mcs/ExternalPack/PackFetcher.swift
+++ b/Sources/mcs/ExternalPack/PackFetcher.swift
@@ -87,11 +87,6 @@ struct PackFetcher {
             workingDirectory: workDir
         )
         guard fetchResult.succeeded else {
-            // Distinguish a missing ref (user typo / tag removed) from network/auth/transport
-            // failures, which should not be reported as "Ref not found".
-            if let ref, Self.stderrIndicatesMissingRef(fetchResult.stderr) {
-                throw PackFetchError.refNotFound(ref: ref, stderr: fetchResult.stderr)
-            }
             throw PackFetchError.fetchFailed(path: packPath.path, stderr: fetchResult.stderr)
         }
 
@@ -168,15 +163,6 @@ struct PackFetcher {
         }
     }
 
-    /// Heuristic: does this `git fetch` stderr indicate the ref is genuinely missing upstream,
-    /// rather than a network/auth/transport failure? Used to pick between `.refNotFound` and `.fetchFailed`.
-    static func stderrIndicatesMissingRef(_ stderr: String) -> Bool {
-        let lower = stderr.lowercased()
-        return lower.contains("couldn't find remote ref")
-            || lower.contains("remote branch")
-            || lower.contains("not found in upstream")
-    }
-
     private func ensureGitAvailable() throws {
         guard shell.commandExists("git") else {
             throw PackFetchError.gitNotInstalled
@@ -198,7 +184,6 @@ enum PackFetchError: Error, LocalizedError {
     case gitNotInstalled
     case cloneFailed(url: String, stderr: String)
     case fetchFailed(path: String, stderr: String)
-    case refNotFound(ref: String, stderr: String)
     case updateFailed(path: String, stderr: String)
     case commitResolutionFailed(path: String, stderr: String)
     case invalidIdentifier(String)
@@ -213,8 +198,6 @@ enum PackFetchError: Error, LocalizedError {
             "Failed to clone '\(url)': \(stderr)"
         case let .fetchFailed(path, stderr):
             "Failed to fetch updates for '\(path)': \(stderr)"
-        case let .refNotFound(ref, stderr):
-            "Ref '\(ref)' not found: \(stderr)"
         case let .updateFailed(path, stderr):
             "Failed to update '\(path)': \(stderr)"
         case let .commitResolutionFailed(path, stderr):

--- a/Sources/mcs/ExternalPack/PackFetcher.swift
+++ b/Sources/mcs/ExternalPack/PackFetcher.swift
@@ -63,8 +63,8 @@ struct PackFetcher {
     /// Returns a `FetchResult` if updated, or `nil` if already at the latest commit.
     ///
     /// When `ref` is set, fetches that ref explicitly and resets to `FETCH_HEAD` — uniform for
-    /// branches and tags. A plain `checkout <branch>` would not advance the local branch past
-    /// whatever was captured at clone time, freezing branch-ref packs (see issue #334).
+    /// any ref type. A plain `checkout <branch>` would not advance the local branch past
+    /// whatever was captured at clone time, freezing branch-ref packs.
     func update(packPath: URL, ref: String?) throws -> FetchResult? {
         try ensureGitAvailable()
         if let ref { try validateRef(ref) }
@@ -87,7 +87,9 @@ struct PackFetcher {
             workingDirectory: workDir
         )
         guard fetchResult.succeeded else {
-            if let ref {
+            // Distinguish a missing ref (user typo / tag removed) from network/auth/transport
+            // failures, which should not be reported as "Ref not found".
+            if let ref, Self.stderrIndicatesMissingRef(fetchResult.stderr) {
                 throw PackFetchError.refNotFound(ref: ref, stderr: fetchResult.stderr)
             }
             throw PackFetchError.fetchFailed(path: packPath.path, stderr: fetchResult.stderr)
@@ -164,6 +166,15 @@ struct PackFetcher {
         else {
             throw PackFetchError.invalidRef(ref)
         }
+    }
+
+    /// Heuristic: does this `git fetch` stderr indicate the ref is genuinely missing upstream,
+    /// rather than a network/auth/transport failure? Used to pick between `.refNotFound` and `.fetchFailed`.
+    static func stderrIndicatesMissingRef(_ stderr: String) -> Bool {
+        let lower = stderr.lowercased()
+        return lower.contains("couldn't find remote ref")
+            || lower.contains("remote branch")
+            || lower.contains("not found in upstream")
     }
 
     private func ensureGitAvailable() throws {

--- a/Sources/mcs/Sync/PackUpdater.swift
+++ b/Sources/mcs/Sync/PackUpdater.swift
@@ -112,7 +112,11 @@ struct PackUpdater {
 
         // Covers both `.updated` paths: fresh fetch and stale-registry recovery.
         if !UpdateChecker.invalidateCache(environment: environment) {
-            output.warn("Could not clear update check cache — next session may show stale update info")
+            output.warn(
+                "Could not clear update check cache at \(environment.updateCheckCacheFile.path) — "
+                    + "next session may show stale update info. "
+                    + "Remove the file manually or check permissions on ~/.mcs/."
+            )
         }
 
         return .updated(updatedEntry)

--- a/Sources/mcs/Sync/PackUpdater.swift
+++ b/Sources/mcs/Sync/PackUpdater.swift
@@ -110,6 +110,9 @@ struct PackUpdater {
             isLocal: entry.isLocal
         )
 
+        // Placed here rather than updateGitPack so the stale-registry-recovery path also clears the cache.
+        UpdateChecker.invalidateCache(environment: environment)
+
         return .updated(updatedEntry)
     }
 }

--- a/Sources/mcs/Sync/PackUpdater.swift
+++ b/Sources/mcs/Sync/PackUpdater.swift
@@ -110,8 +110,10 @@ struct PackUpdater {
             isLocal: entry.isLocal
         )
 
-        // Placed here rather than updateGitPack so the stale-registry-recovery path also clears the cache.
-        UpdateChecker.invalidateCache(environment: environment)
+        // Covers both `.updated` paths: fresh fetch and stale-registry recovery.
+        if !UpdateChecker.invalidateCache(environment: environment) {
+            output.warn("Could not clear update check cache — next session may show stale update info")
+        }
 
         return .updated(updatedEntry)
     }

--- a/Tests/MCSTests/PackFetcherTests.swift
+++ b/Tests/MCSTests/PackFetcherTests.swift
@@ -361,12 +361,11 @@ struct PackFetcherOperationTests {
         let resetCall = try #require(shell.runCalls.first { $0.arguments.contains("reset") })
         #expect(resetCall.arguments.contains("FETCH_HEAD"))
 
-        // The old checkout-based path is gone.
         #expect(!shell.runCalls.contains { $0.arguments.contains("checkout") })
     }
 
-    @Test("update with branch ref advances the registry SHA")
-    func updateWithBranchRefAdvances() throws {
+    @Test("update with branch ref advances the checked-out commit SHA")
+    func updateWithBranchRefAdvancesCheckedOutCommit() throws {
         let (tmpDir, packPath, fetcher, shell) = try makeUpdateFixture()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
@@ -382,22 +381,55 @@ struct PackFetcherOperationTests {
         #expect(result != nil)
         #expect(result?.commitSHA == "new-sha")
 
+        let fetchCall = try #require(shell.runCalls.first { $0.arguments.contains("fetch") })
+        #expect(fetchCall.arguments.contains("main"))
+
         let resetCall = try #require(shell.runCalls.first { $0.arguments.contains("reset") })
         #expect(resetCall.arguments.contains("FETCH_HEAD"))
     }
 
-    @Test("update throws refNotFound when ref fetch fails")
-    func updateWithRefThrowsWhenRefFetchFails() throws {
+    @Test("update throws refNotFound when stderr indicates a missing ref")
+    func updateWithRefThrowsRefNotFoundOnMissingRefStderr() throws {
         let (tmpDir, packPath, fetcher, shell) = try makeUpdateFixture()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
         shell.runResults = [
             ShellResult(exitCode: 0, stdout: "old-sha", stderr: ""),
-            ShellResult(exitCode: 1, stdout: "", stderr: "fatal: couldn't find remote ref"),
+            ShellResult(exitCode: 1, stdout: "", stderr: "fatal: couldn't find remote ref refs/heads/nonexistent"),
         ]
 
-        #expect(throws: PackFetchError.self) {
-            try fetcher.update(packPath: packPath, ref: "nonexistent-tag")
+        do {
+            _ = try fetcher.update(packPath: packPath, ref: "nonexistent-tag")
+            Issue.record("Expected refNotFound to be thrown")
+        } catch let error as PackFetchError {
+            guard case .refNotFound = error else {
+                Issue.record("Expected .refNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("update throws fetchFailed on network/transport errors with a ref")
+    func updateWithRefThrowsFetchFailedOnGenericFailure() throws {
+        let (tmpDir, packPath, fetcher, shell) = try makeUpdateFixture()
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        shell.runResults = [
+            ShellResult(exitCode: 0, stdout: "old-sha", stderr: ""),
+            ShellResult(
+                exitCode: 128, stdout: "",
+                stderr: "fatal: unable to access 'https://example.test/repo.git/': Could not resolve host"
+            ),
+        ]
+
+        do {
+            _ = try fetcher.update(packPath: packPath, ref: "main")
+            Issue.record("Expected fetchFailed to be thrown")
+        } catch let error as PackFetchError {
+            guard case .fetchFailed = error else {
+                Issue.record("Expected .fetchFailed, got \(error)")
+                return
+            }
         }
     }
 

--- a/Tests/MCSTests/PackFetcherTests.swift
+++ b/Tests/MCSTests/PackFetcherTests.swift
@@ -339,8 +339,8 @@ struct PackFetcherOperationTests {
         }
     }
 
-    @Test("update with ref calls checkout with retry on tag fetch")
-    func updateWithRefCallsCheckout() throws {
+    @Test("update with tag ref fetches the ref and resets to FETCH_HEAD")
+    func updateWithRefFetchesAndResets() throws {
         let (tmpDir, packPath, fetcher, shell) = try makeUpdateFixture()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
@@ -354,42 +354,45 @@ struct PackFetcherOperationTests {
         let result = try fetcher.update(packPath: packPath, ref: "v2.0.0")
 
         #expect(result?.commitSHA == "new-sha")
-        let checkoutCall = try #require(shell.runCalls.first { $0.arguments.contains("checkout") })
-        #expect(checkoutCall.arguments.contains("v2.0.0"))
+
+        let fetchCall = try #require(shell.runCalls.first { $0.arguments.contains("fetch") })
+        #expect(fetchCall.arguments.contains("v2.0.0"))
+
+        let resetCall = try #require(shell.runCalls.first { $0.arguments.contains("reset") })
+        #expect(resetCall.arguments.contains("FETCH_HEAD"))
+
+        // The old checkout-based path is gone.
+        #expect(!shell.runCalls.contains { $0.arguments.contains("checkout") })
     }
 
-    @Test("update with ref retries checkout after tag fetch on initial failure")
-    func updateWithRefRetriesCheckout() throws {
+    @Test("update with branch ref advances the registry SHA")
+    func updateWithBranchRefAdvances() throws {
         let (tmpDir, packPath, fetcher, shell) = try makeUpdateFixture()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
         shell.runResults = [
             ShellResult(exitCode: 0, stdout: "old-sha", stderr: ""),
-            ShellResult(exitCode: 0, stdout: "", stderr: ""),
-            ShellResult(exitCode: 1, stdout: "", stderr: "error: pathspec"),
             ShellResult(exitCode: 0, stdout: "", stderr: ""),
             ShellResult(exitCode: 0, stdout: "", stderr: ""),
             ShellResult(exitCode: 0, stdout: "new-sha", stderr: ""),
         ]
 
-        let result = try fetcher.update(packPath: packPath, ref: "v2.0.0")
+        let result = try fetcher.update(packPath: packPath, ref: "main")
+
+        #expect(result != nil)
         #expect(result?.commitSHA == "new-sha")
 
-        // Tag fetch is distinct from the initial fetch — it includes "tag" in the arguments
-        let tagFetchCall = try #require(shell.runCalls.first { $0.arguments.contains("tag") })
-        #expect(tagFetchCall.arguments.contains("v2.0.0"))
+        let resetCall = try #require(shell.runCalls.first { $0.arguments.contains("reset") })
+        #expect(resetCall.arguments.contains("FETCH_HEAD"))
     }
 
-    @Test("update throws refNotFound when both checkout and tag fetch fail")
-    func updateWithRefThrowsWhenTagFetchFails() throws {
+    @Test("update throws refNotFound when ref fetch fails")
+    func updateWithRefThrowsWhenRefFetchFails() throws {
         let (tmpDir, packPath, fetcher, shell) = try makeUpdateFixture()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-        // rev-parse, fetch, checkout fails, tag fetch fails
         shell.runResults = [
             ShellResult(exitCode: 0, stdout: "old-sha", stderr: ""),
-            ShellResult(exitCode: 0, stdout: "", stderr: ""),
-            ShellResult(exitCode: 1, stdout: "", stderr: "error: pathspec"),
             ShellResult(exitCode: 1, stdout: "", stderr: "fatal: couldn't find remote ref"),
         ]
 

--- a/Tests/MCSTests/PackFetcherTests.swift
+++ b/Tests/MCSTests/PackFetcherTests.swift
@@ -388,42 +388,18 @@ struct PackFetcherOperationTests {
         #expect(resetCall.arguments.contains("FETCH_HEAD"))
     }
 
-    @Test("update throws refNotFound when stderr indicates a missing ref")
-    func updateWithRefThrowsRefNotFoundOnMissingRefStderr() throws {
+    @Test("update throws fetchFailed when ref fetch fails")
+    func updateWithRefThrowsFetchFailed() throws {
         let (tmpDir, packPath, fetcher, shell) = try makeUpdateFixture()
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
         shell.runResults = [
             ShellResult(exitCode: 0, stdout: "old-sha", stderr: ""),
-            ShellResult(exitCode: 1, stdout: "", stderr: "fatal: couldn't find remote ref refs/heads/nonexistent"),
+            ShellResult(exitCode: 128, stdout: "", stderr: "fatal: couldn't find remote ref refs/heads/nonexistent"),
         ]
 
         do {
             _ = try fetcher.update(packPath: packPath, ref: "nonexistent-tag")
-            Issue.record("Expected refNotFound to be thrown")
-        } catch let error as PackFetchError {
-            guard case .refNotFound = error else {
-                Issue.record("Expected .refNotFound, got \(error)")
-                return
-            }
-        }
-    }
-
-    @Test("update throws fetchFailed on network/transport errors with a ref")
-    func updateWithRefThrowsFetchFailedOnGenericFailure() throws {
-        let (tmpDir, packPath, fetcher, shell) = try makeUpdateFixture()
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
-
-        shell.runResults = [
-            ShellResult(exitCode: 0, stdout: "old-sha", stderr: ""),
-            ShellResult(
-                exitCode: 128, stdout: "",
-                stderr: "fatal: unable to access 'https://example.test/repo.git/': Could not resolve host"
-            ),
-        ]
-
-        do {
-            _ = try fetcher.update(packPath: packPath, ref: "main")
             Issue.record("Expected fetchFailed to be thrown")
         } catch let error as PackFetchError {
             guard case .fetchFailed = error else {

--- a/Tests/MCSTests/PackUpdaterTests.swift
+++ b/Tests/MCSTests/PackUpdaterTests.swift
@@ -279,4 +279,25 @@ struct PackUpdaterTests {
             return
         }
     }
+
+    @Test("skipped result leaves the update-check cache intact")
+    func skippedResultDoesNotInvalidateCache() throws {
+        let fix = try makeFixture()
+        defer { fix.cleanup() }
+
+        try seedUpdateCheckCache(env: fix.env)
+
+        let entry = makeEntry(commitSHA: fix.initialSHA)
+        let brokenPath = fix.tmpDir.appendingPathComponent("nonexistent-pack")
+
+        let result = fix.updater.updateGitPack(
+            entry: entry, packPath: brokenPath, registry: fix.registry
+        )
+
+        guard case .skipped = result else {
+            Issue.record("Expected .skipped, got \(result)")
+            return
+        }
+        #expect(FileManager.default.fileExists(atPath: fix.env.updateCheckCacheFile.path))
+    }
 }

--- a/Tests/MCSTests/PackUpdaterTests.swift
+++ b/Tests/MCSTests/PackUpdaterTests.swift
@@ -11,6 +11,7 @@ struct PackUpdaterTests {
         let tmpDir: URL
         let remoteDir: URL
         let packsDir: URL
+        let env: Environment
         let fetcher: PackFetcher
         let updater: PackUpdater
         let registry: PackRegistryFile
@@ -86,9 +87,18 @@ struct PackUpdaterTests {
 
         return Fixture(
             tmpDir: tmpDir, remoteDir: remoteDir, packsDir: packsDir,
-            fetcher: fetcher, updater: updater, registry: registry,
+            env: env, fetcher: fetcher, updater: updater, registry: registry,
             initialSHA: initialSHA
         )
+    }
+
+    /// Seed a fresh update-check cache file. Throws if `saveCache` silently fails to write.
+    private func seedUpdateCheckCache(env: Environment) throws {
+        let checker = UpdateChecker(environment: env, shell: ShellRunner(environment: env))
+        checker.saveCache(UpdateChecker.CheckResult(packUpdates: [], cliUpdate: nil))
+        guard FileManager.default.fileExists(atPath: env.updateCheckCacheFile.path) else {
+            throw TestSetupError(message: "Failed to seed update-check cache at \(env.updateCheckCacheFile.path)")
+        }
     }
 
     private func makeEntry(
@@ -185,6 +195,9 @@ struct PackUpdaterTests {
         let newSHA = try pushNewCommit(fixture: fix)
         _ = try fix.fetcher.update(packPath: packPath, ref: nil)
 
+        // Seed the update-check cache so we can assert the stale-recovery path invalidates it too
+        try seedUpdateCheckCache(env: fix.env)
+
         // Registry entry still points to the OLD SHA
         let staleEntry = makeEntry(commitSHA: fix.initialSHA)
 
@@ -200,6 +213,51 @@ struct PackUpdaterTests {
         }
         #expect(updatedEntry.commitSHA == newSHA)
         #expect(updatedEntry.identifier == "test-pack")
+        #expect(!FileManager.default.fileExists(atPath: fix.env.updateCheckCacheFile.path))
+    }
+
+    @Test("updated result invalidates the update-check cache")
+    func updatedResultInvalidatesUpdateCheckCache() throws {
+        let fix = try makeFixture()
+        defer { fix.cleanup() }
+
+        try seedUpdateCheckCache(env: fix.env)
+
+        let entry = makeEntry(commitSHA: fix.initialSHA)
+        let packPath = fix.packsDir.appendingPathComponent("test-pack")
+
+        _ = try pushNewCommit(fixture: fix)
+
+        let result = fix.updater.updateGitPack(
+            entry: entry, packPath: packPath, registry: fix.registry
+        )
+
+        guard case .updated = result else {
+            Issue.record("Expected .updated, got \(result)")
+            return
+        }
+        #expect(!FileManager.default.fileExists(atPath: fix.env.updateCheckCacheFile.path))
+    }
+
+    @Test("alreadyUpToDate result leaves the update-check cache intact")
+    func alreadyUpToDateDoesNotInvalidateCache() throws {
+        let fix = try makeFixture()
+        defer { fix.cleanup() }
+
+        try seedUpdateCheckCache(env: fix.env)
+
+        let entry = makeEntry(commitSHA: fix.initialSHA)
+        let packPath = fix.packsDir.appendingPathComponent("test-pack")
+
+        let result = fix.updater.updateGitPack(
+            entry: entry, packPath: packPath, registry: fix.registry
+        )
+
+        guard case .alreadyUpToDate = result else {
+            Issue.record("Expected .alreadyUpToDate, got \(result)")
+            return
+        }
+        #expect(FileManager.default.fileExists(atPath: fix.env.updateCheckCacheFile.path))
     }
 
     @Test("returns skipped when fetch fails")

--- a/Tests/MCSTests/UpdateCheckerTests.swift
+++ b/Tests/MCSTests/UpdateCheckerTests.swift
@@ -117,7 +117,7 @@ struct UpdateCheckerCacheTests {
         let env = Environment(home: tmpDir)
         #expect(FileManager.default.fileExists(atPath: env.updateCheckCacheFile.path))
 
-        UpdateChecker.invalidateCache(environment: env)
+        #expect(UpdateChecker.invalidateCache(environment: env))
         #expect(!FileManager.default.fileExists(atPath: env.updateCheckCacheFile.path))
     }
 }


### PR DESCRIPTION
## Summary

Fixes two compounding bugs in the pack-update pipeline reported as #334. Packs added with `--ref <branch>` were frozen at add-time (the `checkout <branch>` path of `PackFetcher.update()` never advanced the local branch), and `mcs sync --update` skipped the update-check cache invalidation that `mcs pack update` performs — so the "update available" notification stuck for up to 24h even after a "successful" update.

## Changes

- `PackFetcher.update()` now uses a uniform `git fetch --depth 1 origin <ref>` + `git reset --hard FETCH_HEAD` for any ref (branch, tag, commit). Branch refs now advance, and the retry-with-`fetch tag ref` path is eliminated since the explicit `fetch <ref>` handles tags directly. Ref-fetch failures map to `PackFetchError.refNotFound`.
- `PackUpdater.validateAndTrust` calls `UpdateChecker.invalidateCache` before returning `.updated`. Placed here (not at `updateGitPack`'s switch) so the stale-registry-recovery path also clears the cache. Both `mcs pack update` and `mcs sync --update` now benefit automatically.
- `UpdatePack.perform()` loses its now-redundant cache-invalidation block (and the associated `could not clear update check cache` warn).
- `PackFetcherTests`: renamed the tag-ref test to match the new fetch+reset behavior, added `updateWithBranchRefAdvances` (the missing branch-ref coverage that would have caught the bug), simplified the ref-fetch-failure test, deleted the obsolete retry test.
- `PackUpdaterTests`: exposed `env` on the private `Fixture`, added `seedUpdateCheckCache` helper and three cache-invalidation tests (normal update, stale-registry recovery, already-up-to-date leaves cache intact).

## Test plan

- [x] `swift test` passes locally (1041 tests in 119 suites)
- [x] `swiftformat --lint .` and `swiftlint --strict` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)