### PR TITLE
#338 Phase 2: Author-supplied ignore: field on techpack.yaml

### DIFF
--- a/Sources/mcs/Core/FileHasher.swift
+++ b/Sources/mcs/Core/FileHasher.swift
@@ -8,8 +8,12 @@ enum FileHasher {
     /// Compute SHA-256 hash of a file.
     static func sha256(of url: URL) throws -> String {
         let data = try Data(contentsOf: url)
-        let digest = SHA256.hash(data: data)
-        return digest.map { String(format: "%02x", $0) }.joined()
+        return sha256(data: data)
+    }
+
+    /// Compute SHA-256 hex digest of an in-memory byte buffer.
+    static func sha256(data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
     /// Result of hashing all files in a directory, with per-file error resilience.

--- a/Sources/mcs/Core/GlobMatcher.swift
+++ b/Sources/mcs/Core/GlobMatcher.swift
@@ -1,0 +1,42 @@
+import Darwin
+import Foundation
+
+/// Thin wrapper over POSIX `fnmatch(3)` for path-vs-pattern matching.
+///
+/// Used by the `techpack.yaml` `ignore:` field (issue #338). Semantics:
+/// - `*` matches any sequence of non-`/` characters.
+/// - `?` matches a single non-`/` character.
+/// - `[...]` matches one character from the set.
+/// - `FNM_PATHNAME` is on: `*` does not cross `/`. To silence an entire directory
+///   tree, authors should write either `docs/` (trailing slash — see below) or an
+///   explicit prefix match.
+///
+/// **POSIX, not gitignore.** This matcher does NOT support `**` recursion. If pack
+/// authors need deep globbing, we'll need a gitignore-semantics matcher; start with
+/// POSIX glob and expand when real use cases appear.
+enum GlobMatcher {
+    /// Returns `true` iff `path` matches `pattern`.
+    ///
+    /// Directory-suffix convention: a pattern ending in `/` (e.g. `docs/`) matches
+    /// any path whose first segment is the directory name. This is the intuitive
+    /// "silence this whole directory" behavior pack authors expect, layered on top
+    /// of `fnmatch` since POSIX globs have no native notion of directory trees.
+    static func matches(_ pattern: String, path: String) -> Bool {
+        let trimmed = pattern.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return false }
+
+        // Directory-suffix shortcut: `docs/` silences `docs/guide.md`, `docs/sub/x.md`, etc.
+        if trimmed.hasSuffix("/") {
+            let dirName = String(trimmed.dropLast())
+            guard !dirName.isEmpty else { return false }
+            return path == dirName || path.hasPrefix("\(dirName)/")
+        }
+
+        let result = pattern.withCString { patternCStr in
+            path.withCString { pathCStr in
+                fnmatch(patternCStr, pathCStr, FNM_PATHNAME)
+            }
+        }
+        return result == 0
+    }
+}

--- a/Sources/mcs/Core/GlobMatcher.swift
+++ b/Sources/mcs/Core/GlobMatcher.swift
@@ -22,7 +22,7 @@ enum GlobMatcher {
     /// "silence this whole directory" behavior pack authors expect, layered on top
     /// of `fnmatch` since POSIX globs have no native notion of directory trees.
     static func matches(_ pattern: String, path: String) -> Bool {
-        let trimmed = pattern.trimmingCharacters(in: .whitespaces)
+        let trimmed = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
 
         // Directory-suffix shortcut: `docs/` silences `docs/guide.md`, `docs/sub/x.md`, etc.
@@ -32,7 +32,7 @@ enum GlobMatcher {
             return path == dirName || path.hasPrefix("\(dirName)/")
         }
 
-        let result = pattern.withCString { patternCStr in
+        let result = trimmed.withCString { patternCStr in
             path.withCString { pathCStr in
                 fnmatch(patternCStr, pathCStr, FNM_PATHNAME)
             }

--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 
 /// Checks for available updates to tech packs (via `git ls-remote`)
@@ -540,9 +539,14 @@ struct UpdateChecker {
         let manifests = checkPacks ? loadManifestsForIgnoreCheck(entries: entries) : [:]
         let ignoreHashes = checkPacks ? Self.ignoreHashes(manifests: manifests) : [:]
 
+        // Only feed the hash set into cache invalidation when we're actually checking packs.
+        // With `checkPacks == false`, an empty `ignoreHashes` would force a miss against any
+        // prior cache that recorded hashes — defeating the cooldown for the CLI-only check.
+        let cacheInvalidationHashes: [String: String]? = checkPacks ? ignoreHashes : nil
+
         // Serve cached results if still fresh (single disk read), unless explicitly forced
         if !forceRefresh,
-           let cached = loadCache(currentIgnoreHashes: ignoreHashes),
+           let cached = loadCache(currentIgnoreHashes: cacheInvalidationHashes),
            let lastCheck = ISO8601DateFormatter().date(from: cached.timestamp),
            Date().timeIntervalSince(lastCheck) < Self.cooldownInterval {
             return cached.result

--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -140,8 +140,14 @@ struct UpdateChecker {
         // Invalidate if any pack's `ignore:` list changed since the cache was written.
         // A cached suppression could hide updates that authors no longer want silenced,
         // or a cached notification could persist for commits authors have since ignored.
+        // The compare is bidirectional — a pack present in the cache but absent from the
+        // current set (e.g. its manifest just became unreadable) also invalidates, since
+        // its old hash would otherwise stamp stale suppression onto a now-unknown ignore list.
         if let currentIgnoreHashes {
             let cachedHashes = cached.perPackIgnoreHash ?? [:]
+            if Set(cachedHashes.keys) != Set(currentIgnoreHashes.keys) {
+                return nil
+            }
             for (identifier, hash) in currentIgnoreHashes where cachedHashes[identifier] != hash {
                 return nil
             }
@@ -418,6 +424,12 @@ struct UpdateChecker {
     /// no author ignore list" is correct — we never want a manifest read error to surface a
     /// notification that should be suppressed (the never-hide invariant covers fetch/diff
     /// errors, not manifest-read errors, which default to safe).
+    ///
+    /// Forbidden `ignore:` entries (matching `techpack.yaml` or any referenced path) are
+    /// stripped silently here. The same stripping happens loudly at sync-time via
+    /// `sanitizedIgnoreEntries(output:)`; this is the hook-path equivalent — we can't warn
+    /// the user from a SessionStart hook, but we still must not let a malformed local
+    /// manifest suppress notifications about load-bearing files.
     private func loadManifestForIgnoreCheck(
         entry: PackRegistryFile.PackEntry
     ) -> ExternalPackManifest? {
@@ -427,7 +439,8 @@ struct UpdateChecker {
         let manifestURL = packPath.appendingPathComponent(Constants.ExternalPacks.manifestFilename)
         do {
             let raw = try ExternalPackManifest.load(from: manifestURL)
-            return try raw.normalized()
+            let normalized = try raw.normalized()
+            return normalized.silentlySanitizedIgnoreEntries()
         } catch {
             return nil
         }

--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -115,9 +115,9 @@ struct UpdateChecker {
     struct CachedResult: Codable {
         let timestamp: String
         let result: CheckResult
-        /// SHA-256 of each pack's sorted `ignore:` list (issue #338 Phase 2).
-        /// Optional for backward compatibility: caches written by pre-ignore builds decode with nil.
-        /// When present, `loadCache` invalidates if any pack's current `ignore:` hash differs.
+        /// SHA-256 of each pack's sorted `ignore:` list. Optional so pre-ignore caches still
+        /// decode. When present, `loadCache` invalidates if any pack's current hash differs —
+        /// an author edit shouldn't leave stale suppression inside the 24h window.
         let perPackIgnoreHash: [String: String]?
     }
 
@@ -213,7 +213,7 @@ struct UpdateChecker {
     ///    `PackHeuristics.infrastructureFilesForUpdateCheck` (e.g. `README.md` at the pack
     ///    root, but not `hooks/README.md`).
     /// 3. When a manifest is provided, its `ignore:` entries also count as noise
-    ///    (Phase 2 of issue #338 — authors extend the built-in deny-list).
+    ///    Authors extend the built-in deny-list this way.
     /// 4. If all paths are noise → `.suppressed`. Any survivor → `.material(survivors)`.
     ///
     /// Empty input maps to `.suppressed`: `git diff --name-only` only produces empty output
@@ -341,16 +341,12 @@ struct UpdateChecker {
     /// When a remote SHA differs, runs the noise filter (`classifyUpstreamChange`) which may
     /// suppress the notification for README/CI/infra-only commits and advance the registry
     /// baseline so the same commits don't re-trigger.
-    func checkPackUpdates(entries: [PackRegistryFile.PackEntry]) -> [PackUpdate] {
+    func checkPackUpdates(
+        entries: [PackRegistryFile.PackEntry],
+        manifests: [String: ExternalPackManifest] = [:]
+    ) -> [PackUpdate] {
         let gitEntries = entries.filter { !$0.isLocalPack }
         guard !gitEntries.isEmpty else { return [] }
-
-        // Pre-load manifests serially so the parallel classifier loop below doesn't
-        // re-parse YAML per iteration. Absent manifests fall through to nil → built-in
-        // deny-list only (no crash, no hang).
-        let manifests: [String: ExternalPackManifest] = gitEntries.reduce(into: [:]) { dict, entry in
-            dict[entry.identifier] = loadManifestForIgnoreCheck(entry: entry)
-        }
 
         // Each index is written by exactly one iteration. We write through a raw buffer pointer
         // rather than the `Array` subscript so the parallel writes touch only distinct element
@@ -441,20 +437,24 @@ struct UpdateChecker {
     /// key so an author edit to `ignore:` doesn't leave stale suppression in the 24h window.
     static func ignoreHash(manifest: ExternalPackManifest) -> String {
         let sorted = (manifest.ignore ?? []).sorted().joined(separator: "\n")
-        let digest = SHA256.hash(data: Data(sorted.utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
+        return FileHasher.sha256(data: Data(sorted.utf8))
     }
 
-    /// Compute current per-pack `ignore:` hashes for cache invalidation. Skips local packs
-    /// (no upstream → no update check) and packs whose manifests can't be read (treated as
-    /// "no ignore list").
-    func currentIgnoreHashes(entries: [PackRegistryFile.PackEntry]) -> [String: String] {
-        var hashes: [String: String] = [:]
-        for entry in entries where !entry.isLocalPack {
-            guard let manifest = loadManifestForIgnoreCheck(entry: entry) else { continue }
-            hashes[entry.identifier] = Self.ignoreHash(manifest: manifest)
+    /// Pre-load manifests for the noise filter — once per `performCheck` call. Both the
+    /// cache-invalidation hash and the per-pack classifier need the manifest, so loading
+    /// here avoids a second YAML parse per pack.
+    func loadManifestsForIgnoreCheck(
+        entries: [PackRegistryFile.PackEntry]
+    ) -> [String: ExternalPackManifest] {
+        entries.reduce(into: [:]) { dict, entry in
+            guard !entry.isLocalPack else { return }
+            dict[entry.identifier] = loadManifestForIgnoreCheck(entry: entry)
         }
-        return hashes
+    }
+
+    /// Map pre-loaded manifests to their `ignore:` hashes for cache invalidation.
+    static func ignoreHashes(manifests: [String: ExternalPackManifest]) -> [String: String] {
+        manifests.mapValues { ignoreHash(manifest: $0) }
     }
 
     /// Apply collected SHA advances to `registry.yaml` in one load→mutate→save round-trip.
@@ -525,9 +525,11 @@ struct UpdateChecker {
         checkPacks: Bool,
         checkCLI: Bool
     ) -> CheckResult {
-        // Compute current per-pack `ignore:` hashes once. Used to invalidate the cache when
-        // an author edit to `ignore:` would change the suppression outcome (issue #338 Phase 2).
-        let ignoreHashes = checkPacks ? currentIgnoreHashes(entries: entries) : [:]
+        // Load manifests once per call. Both the cache-invalidation hash (`ignoreHashes`) and
+        // the parallel classifier in `checkPackUpdates` need them; loading here avoids a second
+        // YAML parse per pack on the SessionStart-hook hot path.
+        let manifests = checkPacks ? loadManifestsForIgnoreCheck(entries: entries) : [:]
+        let ignoreHashes = checkPacks ? Self.ignoreHashes(manifests: manifests) : [:]
 
         // Serve cached results if still fresh (single disk read), unless explicitly forced
         if !forceRefresh,
@@ -537,7 +539,7 @@ struct UpdateChecker {
             return cached.result
         }
 
-        let packUpdates = checkPacks ? checkPackUpdates(entries: entries) : []
+        let packUpdates = checkPacks ? checkPackUpdates(entries: entries, manifests: manifests) : []
         let cliUpdate = checkCLI ? checkCLIVersion(currentVersion: MCSVersion.current) : nil
         let result = CheckResult(packUpdates: packUpdates, cliUpdate: cliUpdate)
 

--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Checks for available updates to tech packs (via `git ls-remote`)
@@ -114,12 +115,18 @@ struct UpdateChecker {
     struct CachedResult: Codable {
         let timestamp: String
         let result: CheckResult
+        /// SHA-256 of each pack's sorted `ignore:` list (issue #338 Phase 2).
+        /// Optional for backward compatibility: caches written by pre-ignore builds decode with nil.
+        /// When present, `loadCache` invalidates if any pack's current `ignore:` hash differs.
+        let perPackIgnoreHash: [String: String]?
     }
 
     // MARK: - Cache
 
-    /// Load the cached check result. Returns nil if missing, corrupt, or CLI version changed.
-    func loadCache() -> CachedResult? {
+    /// Load the cached check result. Returns nil if missing, corrupt, CLI version changed, or
+    /// (when `currentIgnoreHashes` is provided) any pack's `ignore:` list changed since the cache
+    /// was written.
+    func loadCache(currentIgnoreHashes: [String: String]? = nil) -> CachedResult? {
         guard let data = try? Data(contentsOf: environment.updateCheckCacheFile),
               let cached = try? JSONDecoder().decode(CachedResult.self, from: data)
         else {
@@ -130,14 +137,24 @@ struct UpdateChecker {
            cli.currentVersion != MCSVersion.current {
             return nil
         }
+        // Invalidate if any pack's `ignore:` list changed since the cache was written.
+        // A cached suppression could hide updates that authors no longer want silenced,
+        // or a cached notification could persist for commits authors have since ignored.
+        if let currentIgnoreHashes {
+            let cachedHashes = cached.perPackIgnoreHash ?? [:]
+            for (identifier, hash) in currentIgnoreHashes where cachedHashes[identifier] != hash {
+                return nil
+            }
+        }
         return cached
     }
 
     /// Save check results to the cache file.
-    func saveCache(_ result: CheckResult) {
+    func saveCache(_ result: CheckResult, ignoreHashes: [String: String]? = nil) {
         let cached = CachedResult(
             timestamp: ISO8601DateFormatter().string(from: Date()),
-            result: result
+            result: result,
+            perPackIgnoreHash: ignoreHashes
         )
         do {
             let dir = environment.updateCheckCacheFile.deletingLastPathComponent()
@@ -195,12 +212,17 @@ struct UpdateChecker {
     ///    (e.g. `.github/workflows/ci.yml`) OR the path is a single segment that matches
     ///    `PackHeuristics.infrastructureFilesForUpdateCheck` (e.g. `README.md` at the pack
     ///    root, but not `hooks/README.md`).
-    /// 3. If all paths are noise → `.suppressed`. Any survivor → `.material(survivors)`.
+    /// 3. When a manifest is provided, its `ignore:` entries also count as noise
+    ///    (Phase 2 of issue #338 — authors extend the built-in deny-list).
+    /// 4. If all paths are noise → `.suppressed`. Any survivor → `.material(survivors)`.
     ///
     /// Empty input maps to `.suppressed`: `git diff --name-only` only produces empty output
     /// after a successful diff that found no changed paths, which is a "definitely no
     /// material change" signal — not an unknown one.
-    static func classifyDiffPaths(_ paths: [String]) -> UpstreamChange {
+    static func classifyDiffPaths(
+        _ paths: [String],
+        manifest: ExternalPackManifest? = nil
+    ) -> UpstreamChange {
         // `.whitespacesAndNewlines` (not `.whitespaces`) so a trailing `\r` from CRLF
         // output (git with `core.autocrlf=true`) gets stripped — otherwise `README.md\r`
         // would miss the deny-list and surface as material.
@@ -213,7 +235,12 @@ struct UpdateChecker {
             return .material([Constants.ExternalPacks.manifestFilename])
         }
 
-        let material = cleaned.filter { !isNoisePath($0) }
+        var material: [String] = []
+        for path in cleaned {
+            if isNoisePath(path) { continue }
+            if let manifest, PackHeuristics.isIgnoredByManifest(path, manifest: manifest) { continue }
+            material.append(path)
+        }
         return material.isEmpty ? .suppressed : .material(material)
     }
 
@@ -245,7 +272,14 @@ struct UpdateChecker {
     /// a ref arg and diff against `origin/HEAD` (more reliable across git servers than passing
     /// `HEAD` as a positional ref). When `entry.ref` is set, fetch that ref explicitly and diff
     /// against `FETCH_HEAD`.
-    func classifyUpstreamChange(entry: PackRegistryFile.PackEntry) -> UpstreamChange {
+    ///
+    /// - Parameter manifest: when non-nil, the manifest's `ignore:` list extends the built-in
+    ///   deny-list. Callers pre-load manifests once per pack so the parallel `concurrentPerform`
+    ///   loop doesn't re-parse YAML per iteration.
+    func classifyUpstreamChange(
+        entry: PackRegistryFile.PackEntry,
+        manifest: ExternalPackManifest? = nil
+    ) -> UpstreamChange {
         // `resolvedPath` only validates the path shape; it doesn't stat the filesystem. If the
         // clone was deleted out from under us (e.g. user `rm -rf`'d `~/.mcs/packs/foo`), classify
         // as `.missingClone` instead of letting git fail with a bogus cwd — same outcome at the
@@ -289,7 +323,7 @@ struct UpdateChecker {
         guard diffResult.succeeded else { return .unknown(.diffFailed) }
 
         let paths = diffResult.stdout.split(separator: "\n").map(String.init)
-        return Self.classifyDiffPaths(paths)
+        return Self.classifyDiffPaths(paths, manifest: manifest)
     }
 
     /// Per-iteration result of `checkPackUpdates`. Sum type — exactly one of:
@@ -310,6 +344,13 @@ struct UpdateChecker {
     func checkPackUpdates(entries: [PackRegistryFile.PackEntry]) -> [PackUpdate] {
         let gitEntries = entries.filter { !$0.isLocalPack }
         guard !gitEntries.isEmpty else { return [] }
+
+        // Pre-load manifests serially so the parallel classifier loop below doesn't
+        // re-parse YAML per iteration. Absent manifests fall through to nil → built-in
+        // deny-list only (no crash, no hang).
+        let manifests: [String: ExternalPackManifest] = gitEntries.reduce(into: [:]) { dict, entry in
+            dict[entry.identifier] = loadManifestForIgnoreCheck(entry: entry)
+        }
 
         // Each index is written by exactly one iteration. We write through a raw buffer pointer
         // rather than the `Array` subscript so the parallel writes touch only distinct element
@@ -352,7 +393,7 @@ struct UpdateChecker {
                     remoteSHA: remoteSHA
                 )
 
-                switch classifyUpstreamChange(entry: entry) {
+                switch classifyUpstreamChange(entry: entry, manifest: manifests[entry.identifier]) {
                 case .suppressed:
                     buf[index] = .advance(identifier: entry.identifier, newSHA: remoteSHA)
                 case .material, .unknown:
@@ -374,6 +415,46 @@ struct UpdateChecker {
             applyRegistryAdvances(advances)
         }
         return updates
+    }
+
+    /// Best-effort manifest read for the noise filter's `ignore:` lookup. Falls back to nil
+    /// (built-in deny-list only) if the manifest is unreadable. The semantic of "no manifest →
+    /// no author ignore list" is correct — we never want a manifest read error to surface a
+    /// notification that should be suppressed (the never-hide invariant covers fetch/diff
+    /// errors, not manifest-read errors, which default to safe).
+    private func loadManifestForIgnoreCheck(
+        entry: PackRegistryFile.PackEntry
+    ) -> ExternalPackManifest? {
+        guard let packPath = entry.resolvedPath(packsDirectory: environment.packsDirectory) else {
+            return nil
+        }
+        let manifestURL = packPath.appendingPathComponent(Constants.ExternalPacks.manifestFilename)
+        do {
+            let raw = try ExternalPackManifest.load(from: manifestURL)
+            return try raw.normalized()
+        } catch {
+            return nil
+        }
+    }
+
+    /// SHA-256 of a manifest's sorted, joined `ignore:` entries. Used as a cache invalidation
+    /// key so an author edit to `ignore:` doesn't leave stale suppression in the 24h window.
+    static func ignoreHash(manifest: ExternalPackManifest) -> String {
+        let sorted = (manifest.ignore ?? []).sorted().joined(separator: "\n")
+        let digest = SHA256.hash(data: Data(sorted.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Compute current per-pack `ignore:` hashes for cache invalidation. Skips local packs
+    /// (no upstream → no update check) and packs whose manifests can't be read (treated as
+    /// "no ignore list").
+    func currentIgnoreHashes(entries: [PackRegistryFile.PackEntry]) -> [String: String] {
+        var hashes: [String: String] = [:]
+        for entry in entries where !entry.isLocalPack {
+            guard let manifest = loadManifestForIgnoreCheck(entry: entry) else { continue }
+            hashes[entry.identifier] = Self.ignoreHash(manifest: manifest)
+        }
+        return hashes
     }
 
     /// Apply collected SHA advances to `registry.yaml` in one load→mutate→save round-trip.
@@ -444,8 +525,13 @@ struct UpdateChecker {
         checkPacks: Bool,
         checkCLI: Bool
     ) -> CheckResult {
+        // Compute current per-pack `ignore:` hashes once. Used to invalidate the cache when
+        // an author edit to `ignore:` would change the suppression outcome (issue #338 Phase 2).
+        let ignoreHashes = checkPacks ? currentIgnoreHashes(entries: entries) : [:]
+
         // Serve cached results if still fresh (single disk read), unless explicitly forced
-        if !forceRefresh, let cached = loadCache(),
+        if !forceRefresh,
+           let cached = loadCache(currentIgnoreHashes: ignoreHashes),
            let lastCheck = ISO8601DateFormatter().date(from: cached.timestamp),
            Date().timeIntervalSince(lastCheck) < Self.cooldownInterval {
             return cached.result
@@ -456,7 +542,7 @@ struct UpdateChecker {
         let result = CheckResult(packUpdates: packUpdates, cliUpdate: cliUpdate)
 
         // Always save to cache so the hook can serve fresh data between network checks
-        saveCache(result)
+        saveCache(result, ignoreHashes: ignoreHashes.isEmpty ? nil : ignoreHashes)
 
         return result
     }

--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -138,19 +138,11 @@ struct UpdateChecker {
             return nil
         }
         // Invalidate if any pack's `ignore:` list changed since the cache was written.
-        // A cached suppression could hide updates that authors no longer want silenced,
-        // or a cached notification could persist for commits authors have since ignored.
-        // The compare is bidirectional — a pack present in the cache but absent from the
-        // current set (e.g. its manifest just became unreadable) also invalidates, since
-        // its old hash would otherwise stamp stale suppression onto a now-unknown ignore list.
-        if let currentIgnoreHashes {
-            let cachedHashes = cached.perPackIgnoreHash ?? [:]
-            if Set(cachedHashes.keys) != Set(currentIgnoreHashes.keys) {
-                return nil
-            }
-            for (identifier, hash) in currentIgnoreHashes where cachedHashes[identifier] != hash {
-                return nil
-            }
+        // Dict equality covers both directions: value drift (entry edited) AND key drift
+        // (pack added, removed, or its manifest just became unreadable so it dropped out
+        // of the current set). Either way, stale suppression cannot survive into the next run.
+        if let currentIgnoreHashes, (cached.perPackIgnoreHash ?? [:]) != currentIgnoreHashes {
+            return nil
         }
         return cached
     }
@@ -442,6 +434,10 @@ struct UpdateChecker {
             let normalized = try raw.normalized()
             return normalized.silentlySanitizedIgnoreEntries()
         } catch {
+            if Environment.isDebugMode {
+                let message = "mcs: ignore-check manifest unreadable for '\(entry.identifier)': \(error.localizedDescription)\n"
+                FileHandle.standardError.write(Data(message.utf8))
+            }
             return nil
         }
     }

--- a/Sources/mcs/Export/ManifestBuilder.swift
+++ b/Sources/mcs/Export/ManifestBuilder.swift
@@ -306,7 +306,8 @@ struct ManifestBuilder {
             templates: templates.isEmpty ? nil : templates,
             prompts: prompts.isEmpty ? nil : prompts,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
 
         return ManifestBuildOutput(

--- a/Sources/mcs/ExternalPack/ExternalPackLoader.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackLoader.swift
@@ -82,7 +82,13 @@ struct ExternalPackLoader {
 
     /// Validate a pack directory contains a valid techpack.yaml.
     /// Returns the parsed and validated manifest.
-    func validate(at path: URL) throws -> ExternalPackManifest {
+    ///
+    /// - Parameter sanitizeOutput: When non-nil, forbidden `ignore:` entries are stripped
+    ///   (with a warn log via this output) before strict validation runs. Used by the
+    ///   sync-time load path so a malformed manifest doesn't break the user's workflow;
+    ///   publish-time callers (`mcs pack validate`, `mcs pack add`) leave this nil so
+    ///   authors see hard errors.
+    func validate(at path: URL, sanitizeOutput: CLIOutput? = nil) throws -> ExternalPackManifest {
         let manifestURL = path.appendingPathComponent(Constants.ExternalPacks.manifestFilename)
         let fm = FileManager.default
 
@@ -90,7 +96,7 @@ struct ExternalPackLoader {
             throw LoadError.manifestNotFound(manifestURL.path)
         }
 
-        let manifest: ExternalPackManifest
+        var manifest: ExternalPackManifest
         let raw: ExternalPackManifest
         do {
             raw = try ExternalPackManifest.load(from: manifestURL)
@@ -107,6 +113,11 @@ struct ExternalPackLoader {
                 identifier: raw.identifier,
                 reason: error.localizedDescription
             )
+        }
+
+        // Runtime safety guard: strip forbidden `ignore:` entries before strict validation.
+        if let sanitizeOutput {
+            manifest = manifest.sanitizedIgnoreEntries(output: sanitizeOutput)
         }
 
         // Validate manifest structure
@@ -170,7 +181,11 @@ struct ExternalPackLoader {
             )
         }
 
-        let manifest = try validate(at: packPath)
+        // Sync-time load: sanitize forbidden `ignore:` entries with a warn log so a
+        // malformed manifest (older toolchain, hand-edit) doesn't break the user's sync.
+        // Publish-time callers (`mcs pack validate`, `mcs pack add`) leave sanitizeOutput nil
+        // and surface the same cases as hard errors.
+        let manifest = try validate(at: packPath, sanitizeOutput: CLIOutput())
 
         // Skip trust verification for local packs — scripts change during development
         if !entry.isLocalPack {

--- a/Sources/mcs/ExternalPack/ExternalPackManifest.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackManifest.swift
@@ -189,28 +189,44 @@ extension ExternalPackManifest {
         try validateIgnoreEntries()
     }
 
+    /// Why an `ignore:` entry is forbidden. Both `validateIgnoreEntries` (publish-strict)
+    /// and `sanitizedIgnoreEntries` (runtime-lenient) classify entries via this enum so the
+    /// rule list lives in one place.
+    enum IgnoreEntryRejection {
+        case empty
+        case manifestFile
+        case referencedPath
+
+        var reason: String {
+            switch self {
+            case .empty:
+                "empty entries are not allowed"
+            case .manifestFile:
+                "\(Constants.ExternalPacks.manifestFilename) is always tracked — manifest edits can change the install surface"
+            case .referencedPath:
+                "path is referenced by a component or template. Remove it from `ignore:` or remove the component."
+            }
+        }
+    }
+
+    /// Classify a single `ignore:` entry; returns nil if the entry is acceptable.
+    static func classifyIgnoreEntry(
+        _ entry: String,
+        referenced: Set<String>
+    ) -> IgnoreEntryRejection? {
+        let trimmed = entry.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty { return .empty }
+        if trimmed == Constants.ExternalPacks.manifestFilename { return .manifestFile }
+        if referenced.contains(trimmed) { return .referencedPath }
+        return nil
+    }
+
     private func validateIgnoreEntries() throws {
         guard let ignore, !ignore.isEmpty else { return }
         let referenced = PackHeuristics.referencedPaths(from: self)
         for entry in ignore {
-            let trimmed = entry.trimmingCharacters(in: .whitespaces)
-            if trimmed.isEmpty {
-                throw ManifestError.ignoreEntryLoadBearing(
-                    entry: entry,
-                    reason: "empty entries are not allowed"
-                )
-            }
-            if trimmed == Constants.ExternalPacks.manifestFilename {
-                throw ManifestError.ignoreEntryLoadBearing(
-                    entry: entry,
-                    reason: "\(Constants.ExternalPacks.manifestFilename) is always tracked — manifest edits can change the install surface"
-                )
-            }
-            if referenced.contains(trimmed) {
-                throw ManifestError.ignoreEntryLoadBearing(
-                    entry: entry,
-                    reason: "path is referenced by a component or template. Remove it from `ignore:` or remove the component."
-                )
+            if let rejection = Self.classifyIgnoreEntry(entry, referenced: referenced) {
+                throw ManifestError.ignoreEntryLoadBearing(entry: entry, reason: rejection.reason)
             }
         }
     }
@@ -266,24 +282,14 @@ extension ExternalPackManifest {
         let referenced = PackHeuristics.referencedPaths(from: self)
         var kept: [String] = []
         for entry in ignore {
-            let trimmed = entry.trimmingCharacters(in: .whitespaces)
-            if trimmed.isEmpty {
-                output.warn("Pack '\(identifier)': dropping empty `ignore:` entry")
-                continue
-            }
-            if trimmed == Constants.ExternalPacks.manifestFilename {
-                let manifest = Constants.ExternalPacks.manifestFilename
-                output.warn(
-                    "Pack '\(identifier)': dropping `ignore:` entry '\(entry)' — \(manifest) is always tracked"
-                )
-                continue
-            }
-            if referenced.contains(trimmed) {
-                output.warn("Pack '\(identifier)': dropping `ignore:` entry '\(entry)' — referenced by a component or template")
+            if let rejection = Self.classifyIgnoreEntry(entry, referenced: referenced) {
+                output.warn("Pack '\(identifier)': dropping `ignore:` entry '\(entry)' — \(rejection.reason)")
                 continue
             }
             kept.append(entry)
         }
+        // Empty and absent collapse to nil so downstream callers (e.g. `isIgnoredByManifest`)
+        // can treat "no ignore list" as a single state.
         return ExternalPackManifest(
             schemaVersion: schemaVersion,
             identifier: identifier,

--- a/Sources/mcs/ExternalPack/ExternalPackManifest.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackManifest.swift
@@ -210,14 +210,24 @@ extension ExternalPackManifest {
     }
 
     /// Classify a single `ignore:` entry; returns nil if the entry is acceptable.
+    ///
+    /// `ignore:` is glob-aware (issue #338), so the safety rule must be glob-aware too —
+    /// otherwise patterns like `*.yaml`, `hooks/*`, or `hooks/` would silently bypass the
+    /// "load-bearing files are always tracked" invariant. The entry is rejected whenever
+    /// its pattern *matches* `techpack.yaml` or any referenced path, not just when the
+    /// strings are equal.
     static func classifyIgnoreEntry(
         _ entry: String,
         referenced: Set<String>
     ) -> IgnoreEntryRejection? {
         let trimmed = entry.trimmingCharacters(in: .whitespaces)
         if trimmed.isEmpty { return .empty }
-        if trimmed == Constants.ExternalPacks.manifestFilename { return .manifestFile }
-        if referenced.contains(trimmed) { return .referencedPath }
+        if GlobMatcher.matches(trimmed, path: Constants.ExternalPacks.manifestFilename) {
+            return .manifestFile
+        }
+        for path in referenced where GlobMatcher.matches(trimmed, path: path) {
+            return .referencedPath
+        }
         return nil
     }
 
@@ -278,12 +288,27 @@ extension ExternalPackManifest {
     /// doesn't break the user's workflow — `mcs pack validate` catches the same entries
     /// with a hard error at publish time. Issue #338 belt-and-suspenders.
     func sanitizedIgnoreEntries(output: CLIOutput) -> ExternalPackManifest {
+        sanitizedIgnoreEntries { entry, rejection in
+            output.warn("Pack '\(identifier)': dropping `ignore:` entry '\(entry)' — \(rejection.reason)")
+        }
+    }
+
+    /// Silent counterpart of `sanitizedIgnoreEntries(output:)` — used on hook paths
+    /// (e.g. update-check) where there is no `CLIOutput` to warn through but a malformed
+    /// local manifest still must not silence load-bearing files.
+    func silentlySanitizedIgnoreEntries() -> ExternalPackManifest {
+        sanitizedIgnoreEntries { _, _ in }
+    }
+
+    private func sanitizedIgnoreEntries(
+        rejected: (_ entry: String, _ rejection: IgnoreEntryRejection) -> Void
+    ) -> ExternalPackManifest {
         guard let ignore, !ignore.isEmpty else { return self }
         let referenced = PackHeuristics.referencedPaths(from: self)
         var kept: [String] = []
         for entry in ignore {
             if let rejection = Self.classifyIgnoreEntry(entry, referenced: referenced) {
-                output.warn("Pack '\(identifier)': dropping `ignore:` entry '\(entry)' — \(rejection.reason)")
+                rejected(entry, rejection)
                 continue
             }
             kept.append(entry)

--- a/Sources/mcs/ExternalPack/ExternalPackManifest.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackManifest.swift
@@ -220,7 +220,7 @@ extension ExternalPackManifest {
         _ entry: String,
         referenced: Set<String>
     ) -> IgnoreEntryRejection? {
-        let trimmed = entry.trimmingCharacters(in: .whitespaces)
+        let trimmed = entry.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return .empty }
         if GlobMatcher.matches(trimmed, path: Constants.ExternalPacks.manifestFilename) {
             return .manifestFile

--- a/Sources/mcs/ExternalPack/ExternalPackManifest.swift
+++ b/Sources/mcs/ExternalPack/ExternalPackManifest.swift
@@ -16,6 +16,13 @@ struct ExternalPackManifest: Codable {
     let prompts: [PromptDefinition]?
     let configureProject: ExternalConfigureProject?
     let supplementaryDoctorChecks: [ExternalDoctorCheckDefinition]?
+    /// POSIX-glob patterns (see `GlobMatcher`) that mark paths as non-material:
+    /// - `UpdateChecker`'s noise filter treats matching paths as infrastructure, extending the built-in
+    ///   deny-list (README, LICENSE, etc.) with author-supplied entries.
+    /// - `PackHeuristics.checkUnreferencedFiles` silences unreferenced-file warnings for matching paths.
+    /// Entries cannot reference `techpack.yaml` or any path referenced by a component/template —
+    /// `validate()` rejects those at publish time and the runtime loader strips them defensively.
+    let ignore: [String]?
 }
 
 // MARK: - Loading
@@ -175,6 +182,37 @@ extension ExternalPackManifest {
                 }
             }
         }
+
+        // `ignore:` entries cannot silence load-bearing files (issue #338).
+        // `techpack.yaml` is always material; any path referenced by a component/template
+        // is required for install — silencing it would produce a broken pack.
+        try validateIgnoreEntries()
+    }
+
+    private func validateIgnoreEntries() throws {
+        guard let ignore, !ignore.isEmpty else { return }
+        let referenced = PackHeuristics.referencedPaths(from: self)
+        for entry in ignore {
+            let trimmed = entry.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty {
+                throw ManifestError.ignoreEntryLoadBearing(
+                    entry: entry,
+                    reason: "empty entries are not allowed"
+                )
+            }
+            if trimmed == Constants.ExternalPacks.manifestFilename {
+                throw ManifestError.ignoreEntryLoadBearing(
+                    entry: entry,
+                    reason: "\(Constants.ExternalPacks.manifestFilename) is always tracked — manifest edits can change the install surface"
+                )
+            }
+            if referenced.contains(trimmed) {
+                throw ManifestError.ignoreEntryLoadBearing(
+                    entry: entry,
+                    reason: "path is referenced by a component or template. Remove it from `ignore:` or remove the component."
+                )
+            }
+        }
     }
 
     private func validateDoctorCheck(_ check: ExternalDoctorCheckDefinition) throws {
@@ -213,6 +251,53 @@ extension ExternalPackManifest {
                 throw ManifestError.invalidDoctorCheck(name: check.name, reason: "settingsKeyEquals requires non-empty 'expectedValue'")
             }
         }
+    }
+}
+
+// MARK: - Ignore-entry sanitization (runtime safety guard)
+
+extension ExternalPackManifest {
+    /// Return a copy with forbidden `ignore:` entries stripped, emitting a warning for each.
+    /// Used by the sync-time load path so a malformed manifest (older toolchain, hand-edited)
+    /// doesn't break the user's workflow — `mcs pack validate` catches the same entries
+    /// with a hard error at publish time. Issue #338 belt-and-suspenders.
+    func sanitizedIgnoreEntries(output: CLIOutput) -> ExternalPackManifest {
+        guard let ignore, !ignore.isEmpty else { return self }
+        let referenced = PackHeuristics.referencedPaths(from: self)
+        var kept: [String] = []
+        for entry in ignore {
+            let trimmed = entry.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty {
+                output.warn("Pack '\(identifier)': dropping empty `ignore:` entry")
+                continue
+            }
+            if trimmed == Constants.ExternalPacks.manifestFilename {
+                let manifest = Constants.ExternalPacks.manifestFilename
+                output.warn(
+                    "Pack '\(identifier)': dropping `ignore:` entry '\(entry)' — \(manifest) is always tracked"
+                )
+                continue
+            }
+            if referenced.contains(trimmed) {
+                output.warn("Pack '\(identifier)': dropping `ignore:` entry '\(entry)' — referenced by a component or template")
+                continue
+            }
+            kept.append(entry)
+        }
+        return ExternalPackManifest(
+            schemaVersion: schemaVersion,
+            identifier: identifier,
+            displayName: displayName,
+            description: description,
+            author: author,
+            minMCSVersion: minMCSVersion,
+            components: components,
+            templates: templates,
+            prompts: prompts,
+            configureProject: configureProject,
+            supplementaryDoctorChecks: supplementaryDoctorChecks,
+            ignore: kept.isEmpty ? nil : kept
+        )
     }
 }
 
@@ -260,7 +345,8 @@ extension ExternalPackManifest {
             templates: normalizedTemplates,
             prompts: prompts,
             configureProject: configureProject,
-            supplementaryDoctorChecks: supplementaryDoctorChecks
+            supplementaryDoctorChecks: supplementaryDoctorChecks,
+            ignore: ignore
         )
     }
 }
@@ -282,6 +368,7 @@ enum ManifestError: Error, Equatable, LocalizedError {
     case unresolvedDependency(componentID: String, dependency: String)
     case invalidHookMetadata(componentID: String, reason: String)
     case duplicateDestination(destination: String, fileType: String, componentIDs: [String])
+    case ignoreEntryLoadBearing(entry: String, reason: String)
 
     var errorDescription: String? {
         switch self {
@@ -312,6 +399,8 @@ enum ManifestError: Error, Equatable, LocalizedError {
         case let .duplicateDestination(destination, fileType, componentIDs):
             "Duplicate copyPackFile destination '\(destination)' (fileType: \(fileType))"
                 + " in components: \(componentIDs.joined(separator: ", "))"
+        case let .ignoreEntryLoadBearing(entry, reason):
+            "ignore: entry '\(entry)' is not allowed: \(reason)"
         }
     }
 }

--- a/Sources/mcs/ExternalPack/PackHeuristics.swift
+++ b/Sources/mcs/ExternalPack/PackHeuristics.swift
@@ -93,20 +93,29 @@ enum PackHeuristics {
         for component in manifest.components ?? [] {
             switch component.installAction {
             case let .copyPackFile(config):
-                paths.insert(config.source)
+                paths.insert(normalizeReferencedPath(config.source))
             case let .settingsFile(source):
-                paths.insert(source)
+                paths.insert(normalizeReferencedPath(source))
             default:
                 break
             }
         }
         for template in manifest.templates ?? [] {
-            paths.insert(template.contentFile)
+            paths.insert(normalizeReferencedPath(template.contentFile))
         }
         if let script = manifest.configureProject?.script {
-            paths.insert(script)
+            paths.insert(normalizeReferencedPath(script))
         }
         return paths
+    }
+
+    /// Normalize a referenced path so equivalent expressions collapse to the same key.
+    /// Trims whitespace and strips a leading `./` so `ignore:` validation doesn't miss
+    /// the same file expressed as `hooks/foo.sh` vs `./hooks/foo.sh` vs ` hooks/foo.sh`.
+    private static func normalizeReferencedPath(_ path: String) -> String {
+        var s = path.trimmingCharacters(in: .whitespaces)
+        if s.hasPrefix("./") { s = String(s.dropFirst(2)) }
+        return s
     }
 
     private static func checkUnreferencedFiles(

--- a/Sources/mcs/ExternalPack/PackHeuristics.swift
+++ b/Sources/mcs/ExternalPack/PackHeuristics.swift
@@ -113,9 +113,9 @@ enum PackHeuristics {
     /// Trims whitespace and strips a leading `./` so `ignore:` validation doesn't miss
     /// the same file expressed as `hooks/foo.sh` vs `./hooks/foo.sh` vs ` hooks/foo.sh`.
     private static func normalizeReferencedPath(_ path: String) -> String {
-        var s = path.trimmingCharacters(in: .whitespaces)
-        if s.hasPrefix("./") { s = String(s.dropFirst(2)) }
-        return s
+        var normalized = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.hasPrefix("./") { normalized = String(normalized.dropFirst(2)) }
+        return normalized
     }
 
     private static func checkUnreferencedFiles(

--- a/Sources/mcs/ExternalPack/PackHeuristics.swift
+++ b/Sources/mcs/ExternalPack/PackHeuristics.swift
@@ -84,7 +84,11 @@ enum PackHeuristics {
         "node_modules", "__pycache__", ".build",
     ]
 
-    private static func referencedPaths(from manifest: ExternalPackManifest) -> Set<String> {
+    /// Paths the manifest relies on for its install surface.
+    /// Used by `checkUnreferencedFiles`, by `ExternalPackManifest.validate()` to reject
+    /// load-bearing entries in the `ignore:` list (issue #338), and by the runtime safety
+    /// guard in `ExternalPackLoader` that strips forbidden `ignore:` entries defensively.
+    static func referencedPaths(from manifest: ExternalPackManifest) -> Set<String> {
         var paths = Set<String>()
         for component in manifest.components ?? [] {
             switch component.installAction {
@@ -128,9 +132,12 @@ enum PackHeuristics {
 
         let subdirs = rootContents.filter { url in
             var isDir: ObjCBool = false
-            return fm.fileExists(atPath: url.path, isDirectory: &isDir)
-                && isDir.boolValue
-                && !ignoredDirectories.contains(url.lastPathComponent)
+            guard fm.fileExists(atPath: url.path, isDirectory: &isDir),
+                  isDir.boolValue,
+                  !ignoredDirectories.contains(url.lastPathComponent)
+            else { return false }
+            // Skip subdirectories entirely when the author has ignored them via techpack.yaml.
+            return !isIgnoredByManifest(url.lastPathComponent, manifest: manifest)
         }
 
         var findings: [Finding] = []
@@ -155,16 +162,26 @@ enum PackHeuristics {
 
             for itemURL in contents {
                 let relativePath = "\(dirName)/\(itemURL.lastPathComponent)"
-                if !referencedPaths.contains(relativePath) {
-                    findings.append(Finding(
-                        severity: .warning,
-                        message: "\(relativePath) is not referenced by any component or template"
-                    ))
-                }
+                if referencedPaths.contains(relativePath) { continue }
+                if isIgnoredByManifest(relativePath, manifest: manifest) { continue }
+                findings.append(Finding(
+                    severity: .warning,
+                    message: "\(relativePath) is not referenced by any component or template"
+                ))
             }
         }
 
         return findings
+    }
+
+    /// True when the path (or the directory tree it lives in) matches any `ignore:` entry
+    /// in the manifest. Uses POSIX glob semantics via `GlobMatcher`.
+    static func isIgnoredByManifest(_ path: String, manifest: ExternalPackManifest) -> Bool {
+        guard let ignore = manifest.ignore, !ignore.isEmpty else { return false }
+        for pattern in ignore where GlobMatcher.matches(pattern, path: path) {
+            return true
+        }
+        return false
     }
 
     /// Files at the pack root that are expected infrastructure, not content.

--- a/Tests/MCSTests/CrossPackPromptResolverTests.swift
+++ b/Tests/MCSTests/CrossPackPromptResolverTests.swift
@@ -256,7 +256,8 @@ struct CrossPackPromptResolverTests {
                 ),
             ],
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let adapter = ExternalPackAdapter(
             manifest: manifest,

--- a/Tests/MCSTests/ExternalPackAdapterTests.swift
+++ b/Tests/MCSTests/ExternalPackAdapterTests.swift
@@ -287,7 +287,8 @@ struct ExternalPackAdapterTests {
             ],
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
 
         let adapter = ExternalPackAdapter(manifest: manifest, packPath: tmpDir)
@@ -329,7 +330,8 @@ struct ExternalPackAdapterTests {
             ],
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let adapter = ExternalPackAdapter(manifest: manifest, packPath: packDir)
 
@@ -373,7 +375,8 @@ struct ExternalPackAdapterTests {
             ],
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let adapter = ExternalPackAdapter(manifest: manifest, packPath: packDir)
 
@@ -507,7 +510,8 @@ struct ExternalPackAdapterTests {
             ],
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let adapter = ExternalPackAdapter(manifest: manifest, packPath: packDir)
 
@@ -537,7 +541,8 @@ struct ExternalPackAdapterTests {
                 ),
             ],
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let (adapter, tmpDir) = try makeAdapter(manifest: manifest)
         defer { try? FileManager.default.removeItem(at: tmpDir) }
@@ -579,7 +584,8 @@ struct ExternalPackAdapterTests {
                 ),
             ],
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let (adapter, tmpDir) = try makeAdapter(manifest: manifest)
         defer { try? FileManager.default.removeItem(at: tmpDir) }
@@ -734,7 +740,8 @@ struct ExternalPackAdapterTests {
             templates: nil,
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
     }
 
@@ -752,7 +759,8 @@ struct ExternalPackAdapterTests {
             templates: nil,
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
     }
 

--- a/Tests/MCSTests/ExternalPackManifestTests.swift
+++ b/Tests/MCSTests/ExternalPackManifestTests.swift
@@ -3362,4 +3362,39 @@ struct ExternalPackManifestTests {
         let sanitized = manifest.sanitizedIgnoreEntries(output: CLIOutput())
         #expect(sanitized.ignore == nil)
     }
+
+    @Test("silentlySanitizedIgnoreEntries strips forbidden entries with no warning sink")
+    func silentlySanitizeStripsForbidden() {
+        let component = ExternalComponentDefinition(
+            id: "ignore-pack.hook",
+            displayName: "Hook",
+            description: "Hook script",
+            type: .hookFile,
+            installAction: .copyPackFile(ExternalCopyPackFileConfig(
+                source: "hooks/handler.sh",
+                destination: "handler.sh",
+                fileType: .hook
+            ))
+        )
+        // techpack.yaml AND a referenced source — both forbidden; "docs/" is fine.
+        let manifest = ignoreManifest(
+            ignore: ["docs/", "techpack.yaml", "hooks/handler.sh"],
+            components: [component]
+        )
+        let sanitized = manifest.silentlySanitizedIgnoreEntries()
+        // Forbidden entries dropped, kept entry preserved. No CLIOutput involvement.
+        #expect(sanitized.ignore == ["docs/"])
+    }
+
+    @Test("silentlySanitizedIgnoreEntries on nil ignore: returns nil")
+    func silentlySanitizeNilIsNoop() {
+        let manifest = ignoreManifest(ignore: nil)
+        #expect(manifest.silentlySanitizedIgnoreEntries().ignore == nil)
+    }
+
+    @Test("silentlySanitizedIgnoreEntries collapses an all-forbidden list to nil")
+    func silentlySanitizeAllForbiddenCollapsesToNil() {
+        let manifest = ignoreManifest(ignore: ["techpack.yaml", "  "])
+        #expect(manifest.silentlySanitizedIgnoreEntries().ignore == nil)
+    }
 }

--- a/Tests/MCSTests/ExternalPackManifestTests.swift
+++ b/Tests/MCSTests/ExternalPackManifestTests.swift
@@ -2063,7 +2063,8 @@ struct ExternalPackManifestTests {
             ],
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
 
         #expect(throws: ManifestError.templateSectionMismatch(
@@ -3146,5 +3147,165 @@ struct ExternalPackManifestTests {
         #expect(comp.isRequired == true)
         #expect(comp.hookRegistration?.event == .sessionStart)
         #expect(comp.doctorChecks?.count == 1)
+    }
+
+    // MARK: - ignore: field (issue #338)
+
+    private func ignoreManifest(
+        ignore: [String]?,
+        components: [ExternalComponentDefinition]? = nil,
+        templates: [ExternalTemplateDefinition]? = nil,
+        configureProject: ExternalConfigureProject? = nil
+    ) -> ExternalPackManifest {
+        ExternalPackManifest(
+            schemaVersion: 1,
+            identifier: "ignore-pack",
+            displayName: "Ignore Pack",
+            description: "Pack with ignore: entries",
+            author: nil,
+            minMCSVersion: nil,
+            components: components,
+            templates: templates,
+            prompts: nil,
+            configureProject: configureProject,
+            supplementaryDoctorChecks: nil,
+            ignore: ignore
+        )
+    }
+
+    @Test("ignore: with directory glob validates")
+    func ignoreDirGlobValidates() throws {
+        let manifest = ignoreManifest(ignore: ["docs/", "examples/", "*.md"])
+        try manifest.validate()
+    }
+
+    @Test("ignore: with techpack.yaml is rejected (manifest is always tracked)")
+    func ignoreManifestRejected() {
+        let manifest = ignoreManifest(ignore: ["techpack.yaml"])
+        #expect(throws: ManifestError.self) {
+            try manifest.validate()
+        }
+    }
+
+    @Test("ignore: with empty entry is rejected")
+    func ignoreEmptyRejected() {
+        let manifest = ignoreManifest(ignore: ["docs/", ""])
+        #expect(throws: ManifestError.self) {
+            try manifest.validate()
+        }
+    }
+
+    @Test("ignore: with referenced copyPackFile source is rejected")
+    func ignoreReferencedCopySource() {
+        let component = ExternalComponentDefinition(
+            id: "ignore-pack.hook",
+            displayName: "Hook",
+            description: "Hook script",
+            type: .hookFile,
+            installAction: .copyPackFile(ExternalCopyPackFileConfig(
+                source: "hooks/handler.sh",
+                destination: "handler.sh",
+                fileType: .hook
+            ))
+        )
+        let manifest = ignoreManifest(
+            ignore: ["hooks/handler.sh"],
+            components: [component]
+        )
+        #expect(throws: ManifestError.self) {
+            try manifest.validate()
+        }
+    }
+
+    @Test("ignore: with referenced template contentFile is rejected")
+    func ignoreReferencedTemplate() {
+        let template = ExternalTemplateDefinition(
+            sectionIdentifier: "ignore-pack.main",
+            placeholders: nil,
+            contentFile: "templates/section.md",
+            dependencies: nil
+        )
+        let manifest = ignoreManifest(
+            ignore: ["templates/section.md"],
+            templates: [template]
+        )
+        #expect(throws: ManifestError.self) {
+            try manifest.validate()
+        }
+    }
+
+    @Test("ignore: with referenced configureProject script is rejected")
+    func ignoreReferencedConfigureScript() {
+        let manifest = ignoreManifest(
+            ignore: ["scripts/configure.sh"],
+            configureProject: ExternalConfigureProject(script: "scripts/configure.sh")
+        )
+        #expect(throws: ManifestError.self) {
+            try manifest.validate()
+        }
+    }
+
+    @Test("ignore: nil/empty does not error")
+    func ignoreEmptyOrNilValidates() throws {
+        try ignoreManifest(ignore: nil).validate()
+        try ignoreManifest(ignore: []).validate()
+    }
+
+    @Test("normalized() preserves ignore: entries")
+    func normalizedPreservesIgnore() throws {
+        let manifest = ignoreManifest(ignore: ["docs/", "*.md"])
+        let normalized = try manifest.normalized()
+        #expect(normalized.ignore == ["docs/", "*.md"])
+    }
+
+    // MARK: - sanitizedIgnoreEntries (runtime safety guard)
+
+    @Test("sanitizedIgnoreEntries strips manifest-filename entry")
+    func sanitizeStripsManifestEntry() {
+        let manifest = ignoreManifest(ignore: ["techpack.yaml", "docs/"])
+        let sanitized = manifest.sanitizedIgnoreEntries(output: CLIOutput())
+        #expect(sanitized.ignore == ["docs/"])
+    }
+
+    @Test("sanitizedIgnoreEntries strips empty entry")
+    func sanitizeStripsEmptyEntry() {
+        let manifest = ignoreManifest(ignore: ["", "docs/", "  "])
+        let sanitized = manifest.sanitizedIgnoreEntries(output: CLIOutput())
+        #expect(sanitized.ignore == ["docs/"])
+    }
+
+    @Test("sanitizedIgnoreEntries strips referenced-path entry")
+    func sanitizeStripsReferenced() {
+        let component = ExternalComponentDefinition(
+            id: "ignore-pack.hook",
+            displayName: "Hook",
+            description: "Hook script",
+            type: .hookFile,
+            installAction: .copyPackFile(ExternalCopyPackFileConfig(
+                source: "hooks/handler.sh",
+                destination: "handler.sh",
+                fileType: .hook
+            ))
+        )
+        let manifest = ignoreManifest(
+            ignore: ["hooks/handler.sh", "docs/"],
+            components: [component]
+        )
+        let sanitized = manifest.sanitizedIgnoreEntries(output: CLIOutput())
+        #expect(sanitized.ignore == ["docs/"])
+    }
+
+    @Test("sanitizedIgnoreEntries with all-forbidden entries returns nil ignore")
+    func sanitizeAllStrippedReturnsNil() {
+        let manifest = ignoreManifest(ignore: ["techpack.yaml"])
+        let sanitized = manifest.sanitizedIgnoreEntries(output: CLIOutput())
+        #expect(sanitized.ignore == nil)
+    }
+
+    @Test("sanitizedIgnoreEntries on nil ignore: is a no-op (still nil)")
+    func sanitizeNilIsNoop() {
+        let manifest = ignoreManifest(ignore: nil)
+        let sanitized = manifest.sanitizedIgnoreEntries(output: CLIOutput())
+        #expect(sanitized.ignore == nil)
     }
 }

--- a/Tests/MCSTests/ExternalPackManifestTests.swift
+++ b/Tests/MCSTests/ExternalPackManifestTests.swift
@@ -3251,6 +3251,60 @@ struct ExternalPackManifestTests {
         try ignoreManifest(ignore: []).validate()
     }
 
+    @Test("ignore: glob that matches techpack.yaml is rejected (no bypass via *.yaml)")
+    func ignoreGlobMatchingManifestRejected() {
+        let manifest = ignoreManifest(ignore: ["*.yaml"])
+        #expect(throws: ManifestError.self) {
+            try manifest.validate()
+        }
+    }
+
+    @Test("ignore: directory pattern that contains a referenced file is rejected")
+    func ignoreDirectoryGlobMatchingReferencedRejected() {
+        let component = ExternalComponentDefinition(
+            id: "ignore-pack.hook",
+            displayName: "Hook",
+            description: "Hook script",
+            type: .hookFile,
+            installAction: .copyPackFile(ExternalCopyPackFileConfig(
+                source: "hooks/handler.sh",
+                destination: "handler.sh",
+                fileType: .hook
+            ))
+        )
+        // `hooks/` would silence `hooks/handler.sh` via the directory-suffix shortcut.
+        // Without glob-aware classification this would slip past validate().
+        let manifest = ignoreManifest(
+            ignore: ["hooks/"],
+            components: [component]
+        )
+        #expect(throws: ManifestError.self) {
+            try manifest.validate()
+        }
+    }
+
+    @Test("ignore: with referenced source written as ./hooks/x.sh still rejected")
+    func ignoreReferencedSourceWithDotPrefixNormalized() {
+        let component = ExternalComponentDefinition(
+            id: "ignore-pack.hook",
+            displayName: "Hook",
+            description: "Hook script",
+            type: .hookFile,
+            installAction: .copyPackFile(ExternalCopyPackFileConfig(
+                source: "./hooks/handler.sh",
+                destination: "handler.sh",
+                fileType: .hook
+            ))
+        )
+        let manifest = ignoreManifest(
+            ignore: ["hooks/handler.sh"],
+            components: [component]
+        )
+        #expect(throws: ManifestError.self) {
+            try manifest.validate()
+        }
+    }
+
     @Test("normalized() preserves ignore: entries")
     func normalizedPreservesIgnore() throws {
         let manifest = ignoreManifest(ignore: ["docs/", "*.md"])

--- a/Tests/MCSTests/GlobMatcherTests.swift
+++ b/Tests/MCSTests/GlobMatcherTests.swift
@@ -1,0 +1,57 @@
+@testable import mcs
+import Testing
+
+struct GlobMatcherTests {
+    @Test("Exact path matches itself")
+    func exactPath() {
+        #expect(GlobMatcher.matches("README.md", path: "README.md"))
+        #expect(!GlobMatcher.matches("README.md", path: "readme.md"))
+        #expect(!GlobMatcher.matches("README.md", path: "docs/README.md"))
+    }
+
+    @Test("FNM_PATHNAME — * does not cross /")
+    func starDoesNotCrossSlash() {
+        #expect(GlobMatcher.matches("*.md", path: "README.md"))
+        #expect(!GlobMatcher.matches("*.md", path: "docs/README.md"))
+        #expect(GlobMatcher.matches("docs/*", path: "docs/guide.md"))
+        #expect(!GlobMatcher.matches("docs/*", path: "docs/sub/guide.md"))
+    }
+
+    @Test("Question mark matches a single non-/ character")
+    func questionMark() {
+        #expect(GlobMatcher.matches("file?.txt", path: "file1.txt"))
+        #expect(!GlobMatcher.matches("file?.txt", path: "file12.txt"))
+        #expect(!GlobMatcher.matches("file?.txt", path: "file/.txt"))
+    }
+
+    @Test("Character class matches any single char in set")
+    func characterClass() {
+        #expect(GlobMatcher.matches("file[12].txt", path: "file1.txt"))
+        #expect(GlobMatcher.matches("file[12].txt", path: "file2.txt"))
+        #expect(!GlobMatcher.matches("file[12].txt", path: "file3.txt"))
+    }
+
+    @Test("Trailing slash silences entire directory tree")
+    func directorySuffix() {
+        #expect(GlobMatcher.matches("docs/", path: "docs"))
+        #expect(GlobMatcher.matches("docs/", path: "docs/guide.md"))
+        #expect(GlobMatcher.matches("docs/", path: "docs/sub/guide.md"))
+        #expect(GlobMatcher.matches("docs/", path: "docs/sub/deep/file.md"))
+        #expect(!GlobMatcher.matches("docs/", path: "documentation.md"))
+        #expect(!GlobMatcher.matches("docs/", path: "other/docs.md"))
+    }
+
+    @Test("Empty/whitespace patterns never match")
+    func emptyPattern() {
+        #expect(!GlobMatcher.matches("", path: "anything"))
+        #expect(!GlobMatcher.matches("   ", path: "anything"))
+        #expect(!GlobMatcher.matches("/", path: "anything"))
+    }
+
+    @Test("Glob with extension matches all files of that type at one level")
+    func extensionGlob() {
+        #expect(GlobMatcher.matches("diagrams/*.png", path: "diagrams/architecture.png"))
+        #expect(!GlobMatcher.matches("diagrams/*.png", path: "diagrams/architecture.jpg"))
+        #expect(!GlobMatcher.matches("diagrams/*.png", path: "diagrams/sub/architecture.png"))
+    }
+}

--- a/Tests/MCSTests/GlobMatcherTests.swift
+++ b/Tests/MCSTests/GlobMatcherTests.swift
@@ -54,4 +54,11 @@ struct GlobMatcherTests {
         #expect(!GlobMatcher.matches("diagrams/*.png", path: "diagrams/architecture.jpg"))
         #expect(!GlobMatcher.matches("diagrams/*.png", path: "diagrams/sub/architecture.png"))
     }
+
+    @Test("Whitespace around the pattern is trimmed before matching")
+    func patternWhitespaceTrimmed() {
+        // Without trim, ` README.md ` would never match anything via fnmatch.
+        #expect(GlobMatcher.matches(" README.md ", path: "README.md"))
+        #expect(GlobMatcher.matches("\tdocs/*\n", path: "docs/guide.md"))
+    }
 }

--- a/Tests/MCSTests/PackHeuristicsTests.swift
+++ b/Tests/MCSTests/PackHeuristicsTests.swift
@@ -18,7 +18,8 @@ struct PackHeuristicsTests {
             templates: nil,
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
     }
 
@@ -248,7 +249,8 @@ struct PackHeuristicsTests {
             )],
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
 
@@ -463,7 +465,8 @@ struct PackHeuristicsTests {
             )],
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
 
@@ -489,7 +492,8 @@ struct PackHeuristicsTests {
             templates: nil,
             prompts: nil,
             configureProject: ExternalConfigureProject(script: "configure.sh"),
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
 
@@ -531,7 +535,8 @@ struct PackHeuristicsTests {
             templates: nil,
             prompts: nil,
             configureProject: ExternalConfigureProject(script: "configure.sh"),
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
 
@@ -558,7 +563,8 @@ struct PackHeuristicsTests {
             templates: nil,
             prompts: nil,
             configureProject: ExternalConfigureProject(script: "scripts/configure.sh"),
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
         let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
 
@@ -711,5 +717,98 @@ struct PackHeuristicsTests {
         #expect(dirs.contains(".github"))
         #expect(dirs.contains("node_modules"))
         #expect(dirs.contains(".build"))
+    }
+
+    // MARK: - manifest ignore: silences checkUnreferencedFiles (issue #338 Phase 2)
+
+    @Test("ignore: directory entry silences unreferenced-file warnings for that dir")
+    func ignoreSilencesDirWarnings() throws {
+        let tmpDir = try makeTmpDir(label: "heuristics-ignore")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Create a docs/ directory that is NOT referenced by any component.
+        let docsDir = tmpDir.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
+        try "# Guide".write(
+            to: docsDir.appendingPathComponent("guide.md"),
+            atomically: true, encoding: .utf8
+        )
+
+        let manifestWithoutIgnore = minimalManifest(components: [
+            ExternalComponentDefinition(
+                id: "test-pack.brew",
+                displayName: "Brew",
+                description: "Some package",
+                type: .brewPackage,
+                installAction: .brewInstall(package: "git")
+            ),
+        ])
+        // Without ignore:, docs/guide.md is flagged.
+        let baseFindings = PackHeuristics.check(manifest: manifestWithoutIgnore, packPath: tmpDir)
+        let baseDocsWarnings = baseFindings.filter { $0.message.contains("docs/guide.md") }
+        #expect(baseDocsWarnings.count == 1)
+
+        // With ignore: ["docs/"], no warning.
+        let manifestWithIgnore = ExternalPackManifest(
+            schemaVersion: 1,
+            identifier: "test-pack",
+            displayName: "Test Pack",
+            description: "test",
+            author: nil,
+            minMCSVersion: nil,
+            components: manifestWithoutIgnore.components,
+            templates: nil,
+            prompts: nil,
+            configureProject: nil,
+            supplementaryDoctorChecks: nil,
+            ignore: ["docs/"]
+        )
+        let ignoredFindings = PackHeuristics.check(manifest: manifestWithIgnore, packPath: tmpDir)
+        let ignoredDocsWarnings = ignoredFindings.filter { $0.message.contains("docs/guide.md") }
+        #expect(ignoredDocsWarnings.isEmpty)
+    }
+
+    @Test("ignore: glob entry silences unreferenced-file warnings matching the pattern")
+    func ignoreGlobSilencesWarnings() throws {
+        let tmpDir = try makeTmpDir(label: "heuristics-ignore-glob")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let assetsDir = tmpDir.appendingPathComponent("assets")
+        try FileManager.default.createDirectory(at: assetsDir, withIntermediateDirectories: true)
+        try Data().write(to: assetsDir.appendingPathComponent("logo.png"))
+        try Data().write(to: assetsDir.appendingPathComponent("notes.txt"))
+
+        let manifest = ExternalPackManifest(
+            schemaVersion: 1,
+            identifier: "test-pack",
+            displayName: "Test Pack",
+            description: "test",
+            author: nil,
+            minMCSVersion: nil,
+            components: [
+                ExternalComponentDefinition(
+                    id: "test-pack.brew",
+                    displayName: "Brew",
+                    description: "package",
+                    type: .brewPackage,
+                    installAction: .brewInstall(package: "git")
+                ),
+            ],
+            templates: nil,
+            prompts: nil,
+            configureProject: nil,
+            supplementaryDoctorChecks: nil,
+            ignore: ["assets/*.png"]
+        )
+        let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
+        // logo.png matches the glob → silenced; notes.txt is still flagged.
+        #expect(findings.filter { $0.message.contains("assets/logo.png") }.isEmpty)
+        #expect(findings.contains { $0.message.contains("assets/notes.txt") })
+    }
+
+    @Test("isIgnoredByManifest returns false when manifest has no ignore:")
+    func isIgnoredByManifestEmpty() {
+        let manifest = minimalManifest()
+        #expect(!PackHeuristics.isIgnoredByManifest("docs/guide.md", manifest: manifest))
     }
 }

--- a/Tests/MCSTests/PackWriterTests.swift
+++ b/Tests/MCSTests/PackWriterTests.swift
@@ -26,7 +26,8 @@ struct PackWriterTests {
             templates: nil,
             prompts: nil,
             configureProject: nil,
-            supplementaryDoctorChecks: nil
+            supplementaryDoctorChecks: nil,
+            ignore: nil
         )
     }
 

--- a/Tests/MCSTests/UpdateCheckerTests.swift
+++ b/Tests/MCSTests/UpdateCheckerTests.swift
@@ -937,6 +937,28 @@ struct UpdateCheckerIgnoreFieldTests {
         // Without bidirectional check, the cache would still serve stale suppression for pack-b.
         #expect(checker.loadCache(currentIgnoreHashes: ["pack-a": "hash-a"]) == nil)
     }
+
+    @Test("loadCache without currentIgnoreHashes ignores pack-hash drift (CLI-only check)")
+    func cacheNotInvalidatedWhenIgnoreHashesNotProvided() throws {
+        let tmpDir = try makeTmpDir(label: "ignore-cache-nil")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let env = Environment(home: tmpDir)
+        let cached = UpdateChecker.CachedResult(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            result: UpdateChecker.CheckResult(packUpdates: [], cliUpdate: nil),
+            perPackIgnoreHash: ["pack-a": "hash-a", "pack-b": "hash-b"]
+        )
+        let dir = env.updateCheckCacheFile.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try JSONEncoder().encode(cached).write(to: env.updateCheckCacheFile, options: .atomic)
+
+        let checker = UpdateChecker(environment: env, shell: ShellRunner(environment: env))
+
+        // checkPacks=false path passes nil → cooldown for the CLI check is preserved even when
+        // the cache holds prior pack-hashes.
+        #expect(checker.loadCache(currentIgnoreHashes: nil) != nil)
+    }
 }
 
 // MARK: - Parsing Tests

--- a/Tests/MCSTests/UpdateCheckerTests.swift
+++ b/Tests/MCSTests/UpdateCheckerTests.swift
@@ -21,7 +21,8 @@ struct UpdateCheckerCacheTests {
     private func writeCacheFile(at env: Environment, timestamp: Date, result: UpdateChecker.CheckResult) throws {
         let cached = UpdateChecker.CachedResult(
             timestamp: ISO8601DateFormatter().string(from: timestamp),
-            result: result
+            result: result,
+            perPackIgnoreHash: nil
         )
         let dir = env.updateCheckCacheFile.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -141,7 +142,8 @@ struct UpdateCheckerPerformCheckTests {
     private func writeFreshCache(at env: Environment, result: UpdateChecker.CheckResult) throws {
         let cached = UpdateChecker.CachedResult(
             timestamp: ISO8601DateFormatter().string(from: Date()),
-            result: result
+            result: result,
+            perPackIgnoreHash: nil
         )
         let dir = env.updateCheckCacheFile.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -208,7 +210,8 @@ struct UpdateCheckerPerformCheckTests {
         let staleTimestamp = Date().addingTimeInterval(-90000)
         let cached = UpdateChecker.CachedResult(
             timestamp: ISO8601DateFormatter().string(from: staleTimestamp),
-            result: staleResult
+            result: staleResult,
+            perPackIgnoreHash: nil
         )
         let dir = env.updateCheckCacheFile.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -795,6 +798,101 @@ struct UpdateCheckerPackUpdatesTests {
 
         #expect(updates2.isEmpty)
         #expect(mock2.runCalls.count == 1, "Only ls-remote — no fetch/diff after baseline caught up")
+    }
+}
+
+// MARK: - Manifest ignore: integration (issue #338 Phase 2)
+
+struct UpdateCheckerIgnoreFieldTests {
+    private func ignoreManifest(_ ignore: [String]?) -> ExternalPackManifest {
+        ExternalPackManifest(
+            schemaVersion: 1,
+            identifier: "p",
+            displayName: "P",
+            description: "x",
+            author: nil,
+            minMCSVersion: nil,
+            components: nil,
+            templates: nil,
+            prompts: nil,
+            configureProject: nil,
+            supplementaryDoctorChecks: nil,
+            ignore: ignore
+        )
+    }
+
+    @Test("classifyDiffPaths suppresses paths matched by manifest ignore:")
+    func ignoreSuppressesAuthorPaths() {
+        let manifest = ignoreManifest(["docs/", "examples/"])
+        // docs/guide.md isn't in the built-in deny-list (built-in covers `.github/`, etc.)
+        // so without the manifest it would be material; with it, suppressed.
+        #expect(UpdateChecker.classifyDiffPaths(["docs/guide.md"]) ==
+            .material(["docs/guide.md"]))
+        #expect(UpdateChecker.classifyDiffPaths(["docs/guide.md"], manifest: manifest) ==
+            .suppressed)
+        #expect(UpdateChecker.classifyDiffPaths(["examples/sample.md"], manifest: manifest) ==
+            .suppressed)
+    }
+
+    @Test("classifyDiffPaths still surfaces material paths even with broad ignore:")
+    func ignoreDoesNotHideMaterial() {
+        let manifest = ignoreManifest(["docs/"])
+        let result = UpdateChecker.classifyDiffPaths(
+            ["docs/guide.md", "hooks/handler.sh"],
+            manifest: manifest
+        )
+        #expect(result == .material(["hooks/handler.sh"]))
+    }
+
+    @Test("ignore: cannot override the techpack.yaml-always-material invariant")
+    func ignoreCannotSilenceManifest() {
+        // Even if an author tried to silence techpack.yaml, the supply-chain invariant wins.
+        let manifest = ignoreManifest(["techpack.yaml"])
+        #expect(UpdateChecker.classifyDiffPaths(["techpack.yaml"], manifest: manifest) ==
+            .material(["techpack.yaml"]))
+    }
+
+    @Test("ignoreHash differs when ignore: list changes")
+    func ignoreHashSensitivity() {
+        let a = ignoreManifest(["docs/"])
+        let b = ignoreManifest(["docs/", "examples/"])
+        let c = ignoreManifest(nil)
+
+        #expect(UpdateChecker.ignoreHash(manifest: a) != UpdateChecker.ignoreHash(manifest: b))
+        #expect(UpdateChecker.ignoreHash(manifest: a) != UpdateChecker.ignoreHash(manifest: c))
+    }
+
+    @Test("ignoreHash is order-independent (sorted internally)")
+    func ignoreHashOrderIndependent() {
+        let a = ignoreManifest(["docs/", "examples/"])
+        let b = ignoreManifest(["examples/", "docs/"])
+        #expect(UpdateChecker.ignoreHash(manifest: a) == UpdateChecker.ignoreHash(manifest: b))
+    }
+
+    @Test("loadCache returns nil when current ignore-hash differs from cached")
+    func cacheInvalidatedOnIgnoreHashMismatch() throws {
+        let tmpDir = try makeTmpDir(label: "ignore-cache")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let env = Environment(home: tmpDir)
+        let cached = UpdateChecker.CachedResult(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            result: UpdateChecker.CheckResult(packUpdates: [], cliUpdate: nil),
+            perPackIgnoreHash: ["pack-a": "hash-old"]
+        )
+        let dir = env.updateCheckCacheFile.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(cached)
+        try data.write(to: env.updateCheckCacheFile, options: .atomic)
+
+        let checker = UpdateChecker(environment: env, shell: ShellRunner(environment: env))
+
+        // Same hashes → cache hit
+        #expect(checker.loadCache(currentIgnoreHashes: ["pack-a": "hash-old"]) != nil)
+        // Different hash → cache miss
+        #expect(checker.loadCache(currentIgnoreHashes: ["pack-a": "hash-new"]) == nil)
+        // No-arg call ignores hashes → still hit
+        #expect(checker.loadCache() != nil)
     }
 }
 

--- a/Tests/MCSTests/UpdateCheckerTests.swift
+++ b/Tests/MCSTests/UpdateCheckerTests.swift
@@ -894,6 +894,49 @@ struct UpdateCheckerIgnoreFieldTests {
         // No-arg call ignores hashes → still hit
         #expect(checker.loadCache() != nil)
     }
+
+    @Test("loadCache invalidates when a pack appears in current but not in cached (pack added)")
+    func cacheInvalidatedOnPackAdded() throws {
+        let tmpDir = try makeTmpDir(label: "ignore-cache-add")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let env = Environment(home: tmpDir)
+        let cached = UpdateChecker.CachedResult(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            result: UpdateChecker.CheckResult(packUpdates: [], cliUpdate: nil),
+            perPackIgnoreHash: ["pack-a": "hash-a"]
+        )
+        let dir = env.updateCheckCacheFile.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try JSONEncoder().encode(cached).write(to: env.updateCheckCacheFile, options: .atomic)
+
+        let checker = UpdateChecker(environment: env, shell: ShellRunner(environment: env))
+
+        // pack-b just got added; cached set is missing it → invalidate
+        #expect(checker.loadCache(currentIgnoreHashes: ["pack-a": "hash-a", "pack-b": "hash-b"]) == nil)
+    }
+
+    @Test("loadCache invalidates when a pack disappears from current (manifest unreadable / removed)")
+    func cacheInvalidatedOnPackDropped() throws {
+        let tmpDir = try makeTmpDir(label: "ignore-cache-drop")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let env = Environment(home: tmpDir)
+        let cached = UpdateChecker.CachedResult(
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            result: UpdateChecker.CheckResult(packUpdates: [], cliUpdate: nil),
+            perPackIgnoreHash: ["pack-a": "hash-a", "pack-b": "hash-b"]
+        )
+        let dir = env.updateCheckCacheFile.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try JSONEncoder().encode(cached).write(to: env.updateCheckCacheFile, options: .atomic)
+
+        let checker = UpdateChecker(environment: env, shell: ShellRunner(environment: env))
+
+        // pack-b's manifest is now unreadable → it dropped out of currentIgnoreHashes.
+        // Without bidirectional check, the cache would still serve stale suppression for pack-b.
+        #expect(checker.loadCache(currentIgnoreHashes: ["pack-a": "hash-a"]) == nil)
+    }
 }
 
 // MARK: - Parsing Tests

--- a/docs/creating-tech-packs.md
+++ b/docs/creating-tech-packs.md
@@ -401,6 +401,34 @@ Placeholder substitution works in **templates**, **settings files** (`settingsFi
 
 ---
 
+## Ignoring Non-Material Paths
+
+Pack repos accumulate files that aren't part of the install surface — `docs/`, `examples/`, design assets, screenshots. Two annoyances follow:
+
+- `mcs pack validate` flags every unreferenced file with a warning.
+- Every README/docs/CI commit triggers a "pack update available" notification on every user who has the pack installed, even though `mcs sync` would install the same files.
+
+Add an `ignore:` field at the manifest root to silence both:
+
+```yaml
+identifier: my-pack
+displayName: My Pack
+description: Example
+schemaVersion: 1
+ignore:
+  - docs/
+  - examples/
+  - diagrams/*.png
+```
+
+The engine extends its built-in deny-list (README, LICENSE, `.github/`, `node_modules/`, etc.) with your entries. POSIX glob syntax (`*`, `?`, `[abc]`) — no `**` recursion. A trailing `/` silences the entire directory tree.
+
+You **cannot** put `techpack.yaml` or any path referenced by a component/template in `ignore:` — `mcs pack validate` rejects those entries with a clear error. Manifest edits change the install surface and must always surface to users; silencing referenced files would produce a broken pack.
+
+See the [Schema Reference](techpack-schema.md#the-ignore-field) for full semantics.
+
+---
+
 ## Prompts
 
 Prompts gather values from the user during `mcs sync`. These values are available as `__KEY__` placeholders in templates, settings files, MCP server configs, and copyPackFile artifacts — and as `MCS_RESOLVED_KEY` environment variables in scripts.

--- a/docs/techpack-schema.md
+++ b/docs/techpack-schema.md
@@ -19,6 +19,7 @@ Complete field-by-field reference for `techpack.yaml`. For a tutorial-style intr
 | `prompts` | `[Prompt]` | No | Interactive prompts for `mcs sync` |
 | `configureProject` | `ConfigureProject` | No | Script to run after project configuration |
 | `supplementaryDoctorChecks` | `[DoctorCheck]` | No | Pack-level health checks |
+| `ignore` | `[String]` | No | POSIX-glob paths treated as non-material. See [The `ignore:` field](#the-ignore-field). |
 
 ## Components
 
@@ -511,6 +512,53 @@ The engine validates manifests on load. These rules are enforced:
 | Missing python module | MCP server uses `python -m <module>` but `<module>/` directory not found in the pack |
 
 Infrastructure directories (`.git`, `.github`, `.gitlab`, `.vscode`, `node_modules`, `__pycache__`, `.build`) and common root-level files (`techpack.yaml`, `README.md`, `LICENSE`, `Makefile`, etc.) are excluded from unreferenced-file checks.
+
+---
+
+## The `ignore:` field
+
+Pack authors can extend the engine's built-in deny-list of "non-material" paths via the top-level `ignore:` field. This serves two purposes from one declaration:
+
+- `mcs check-updates` (and the SessionStart hook) treats matching paths as non-material — README/CI/docs-only commits in your pack repo no longer trigger downstream "pack update available" notifications.
+- `mcs pack validate` no longer warns about matching paths as unreferenced files — authors can keep `docs/`, `examples/`, design assets, etc. in the pack repo without noise.
+
+Example:
+
+```yaml
+identifier: my-pack
+displayName: My Pack
+description: Example
+schemaVersion: 1
+ignore:
+  - docs/
+  - examples/
+  - diagrams/*.png
+```
+
+### Semantics
+
+- **Extends the built-ins**, never replaces. The built-in deny-list (README, LICENSE, CHANGELOG, `.github/`, `node_modules/`, `.build/`, etc.) always applies; `ignore:` adds to it.
+- **POSIX glob syntax** (via `fnmatch`):
+  - `*` matches any sequence of non-`/` characters (does not cross directories).
+  - `?` matches a single non-`/` character.
+  - `[abc]` matches one character from the set.
+  - **No `**` recursion** — POSIX globs only.
+- **Trailing `/` silences the entire directory tree.** `docs/` matches `docs`, `docs/guide.md`, `docs/sub/deep.md`. Otherwise `docs/*` would only match one level deep.
+
+### Forbidden entries
+
+`ignore:` cannot silence load-bearing files. Both `mcs pack validate` (publish-time, hard error) and the runtime sync loader (warns and strips) reject:
+
+- `techpack.yaml` — manifest edits change the install surface and must always surface (supply-chain invariant).
+- Any path referenced by a component (`copyPackFile.source`, `settingsFile.source`), template (`contentFile`), or configure script — silencing a file the manifest claims to use would produce a broken pack.
+
+Example error from `mcs pack validate`:
+
+```
+ignore: entry 'hooks/handler.sh' is not allowed: path is referenced by a component or template. Remove it from `ignore:` or remove the component.
+```
+
+If a malformed manifest reaches a user's machine (older mcs version, hand-edit), the sync loader silently strips the forbidden entries with a warning rather than failing the install — authors get loud feedback at publish time, users keep working.
 
 ---
 

--- a/skills/techpack-creator/SKILL.md
+++ b/skills/techpack-creator/SKILL.md
@@ -170,7 +170,7 @@ Generate the pack directory:
 3. **identifier**: lowercase alphanumeric + hyphens, no leading hyphen
 4. **Component IDs**: short names, NO dots (MCS auto-prefixes with `<pack-id>.`)
 5. **YAML field ordering**:
-   - Root: schemaVersion → identifier → displayName → description → author → prompts → components → templates → supplementaryDoctorChecks → configureProject
+   - Root: schemaVersion → identifier → displayName → description → author → prompts → components → templates → supplementaryDoctorChecks → configureProject → ignore
    - Components grouped: brew first → MCP servers → hooks → skills → commands → agents → settings → gitignore
    - Each component: id → displayName → description → dependencies → isRequired → hookEvent/hookMatcher/hookTimeout/hookAsync/hookStatusMessage → shorthand key
 6. **Dependencies**: Always declare them. `npx` MCP servers depend on `node`. `uvx`/`python` servers depend on `python`. Hooks using `jq` depend on `jq`.
@@ -178,6 +178,7 @@ Generate the pack directory:
 8. **MCP scope**: default to `local` (per-user, per-project isolation)
 9. **Prompts before components** in the YAML for readability
 10. **Placeholders**: `__UPPER_SNAKE__` format. Every `__KEY__` used in templates/settings MUST have a matching prompt
+11. **Populate `ignore:` for non-material paths**: When the source repo contains `docs/`, `examples/`, design assets, screenshots, or any directories not referenced by a component/template, add them to a top-level `ignore:` list (POSIX globs, trailing `/` silences the directory tree). This silences `mcs pack validate` unreferenced-file warnings AND stops downstream "pack update available" notifications from firing on doc/CI commits. Never put `techpack.yaml` or referenced paths in `ignore:` — `mcs pack validate` rejects those. Example: `ignore: [docs/, examples/, diagrams/*.png]`.
 
 #### Hook Script Template
 

--- a/skills/techpack-creator/references/techpack-schema.md
+++ b/skills/techpack-creator/references/techpack-schema.md
@@ -39,6 +39,7 @@ everything needed to generate valid manifests without access to the MCS source c
 | `prompts` | [Prompt] | No | Interactive prompts for `mcs sync` |
 | `configureProject` | Object | No | Script to run after project configuration |
 | `supplementaryDoctorChecks` | [DoctorCheck] | No | Pack-level health checks |
+| `ignore` | [String] | No | POSIX-glob paths the engine treats as non-material — silences `mcs pack validate` warnings AND prevents `mcs check-updates` from firing on commits limited to these paths. Cannot include `techpack.yaml` or any referenced component/template path. Trailing `/` silences the whole directory tree. Example: `["docs/", "examples/", "diagrams/*.png"]` |
 
 ---
 

--- a/skills/techpack-creator/references/techpack-schema.md
+++ b/skills/techpack-creator/references/techpack-schema.md
@@ -20,7 +20,8 @@ everything needed to generate valid manifests without access to the MCS source c
 8. [Configure Project](#configure-project)
 9. [Validation Rules](#validation-rules)
 10. [Heuristic Checks](#heuristic-checks)
-11. [Pack Directory Convention](#pack-directory-convention)
+11. [The `ignore:` field](#the-ignore-field)
+12. [Pack Directory Convention](#pack-directory-convention)
 
 ---
 
@@ -464,6 +465,37 @@ Infrastructure files never flagged: `techpack.yaml`, `README.md`, `README`, `LIC
 `requirements.txt`, `Makefile`, `Dockerfile`, `.dockerignore`
 
 Ignored directories: `.git`, `.github`, `.gitlab`, `.vscode`, `node_modules`, `__pycache__`, `.build`
+
+---
+
+## The `ignore:` field
+
+Top-level optional list that extends the engine's built-in deny-list of "non-material" paths. One declaration drives two behaviors:
+
+- `mcs check-updates` (and the SessionStart hook) treats matching paths as non-material, so README/CI/docs-only commits don't trigger downstream "pack update available" notifications.
+- `mcs pack validate` no longer warns about matching paths as unreferenced files.
+
+```yaml
+ignore:
+  - docs/
+  - examples/
+  - diagrams/*.png
+```
+
+### Semantics
+
+- **Extends the built-ins**, never replaces. Built-in deny-list (README, LICENSE, CHANGELOG, `.github/`, `node_modules/`, `.build/`, etc.) always applies.
+- **POSIX glob syntax** via `fnmatch`: `*` (no `/` crossing), `?`, `[abc]`. **No `**` recursion** — POSIX globs only.
+- **Trailing `/` silences the entire directory tree.** `docs/` matches `docs`, `docs/guide.md`, `docs/sub/deep.md`. Without the trailing slash, `docs/*` only matches one level deep.
+
+### Forbidden entries (rejected glob-aware)
+
+`mcs pack validate` rejects with a hard error; the runtime sync loader strips with a warning. Both checks are glob-aware — `*.yaml`, `hooks/*`, or `hooks/` are rejected when they would silence load-bearing files:
+
+- `techpack.yaml` — manifest edits change the install surface and must always surface (supply-chain invariant).
+- Any path referenced by a component (`copyPackFile.source`, `settingsFile.source`), template (`contentFile`), or configure script.
+
+When generating manifests for repos with non-material directories (`docs/`, `examples/`, asset folders), populate `ignore:` so authors don't hit validation warnings or noisy update notifications.
 
 ---
 


### PR DESCRIPTION
## Summary

Builds on #343 (Phase 1 — engine-side built-in deny-list, already merged). Authors can now extend the engine's deny-list of "non-material" paths via a top-level `ignore:` list in `techpack.yaml`. Same field silences two long-standing annoyances: `mcs pack validate` warnings about unreferenced `docs/`, `examples/`, asset directories, AND the "pack update available" notification that fires for every doc/CI commit downstream users see.

## Changes

- New top-level `ignore: [String]` field on `techpack.yaml`. POSIX glob syntax (`*`, `?`, `[...]`); trailing `/` silences the entire directory tree. No `**` recursion (POSIX, not gitignore).
- **Three-tier sanitization**: `mcs pack validate` rejects forbidden entries with a clear error (publish-strict); the runtime sync loader strips them with a warn log so a malformed manifest from an older toolchain or hand-edit doesn't break a user's sync (runtime-lenient); the update-check path silently strips them (hook-silent) so a tampered local manifest can never suppress notifications about load-bearing files.
- **Glob-aware safety rule**: rejection runs `GlobMatcher.matches` against `techpack.yaml` and every referenced component/template/configure-script path — patterns like `*.yaml`, `hooks/*`, or `hooks/` are rejected when they would silence load-bearing files. String-equality alone wouldn't catch this.
- The update-check noise filter consults the manifest's `ignore:` after the built-in deny-list — author entries layer on top, never replace, never override the `techpack.yaml`-always-material invariant.
- Update-check cache now records a SHA-256 of each pack's sorted `ignore:` list. Authoring changes the list → next load invalidates the cache so users see fresh suppression behavior immediately, no 24-hour wait. Bidirectional dict equality covers value drift, pack-added, pack-removed, and manifest-unreadable cases. The new field is optional in the cache schema so caches written by pre-Phase-2 builds still decode.
- Schema reference (`docs/techpack-schema.md`), tutorial (`docs/creating-tech-packs.md`), and the bundled techpack-creator skill (`SKILL.md` + mirrored schema reference) all describe the field with worked examples and forbidden-entry semantics.

## Test plan

- [x] `swift test` passes locally (1138 tests)
- [x] `swiftformat --lint .` and `swiftlint` pass without violations
- [x] CI green

Manual end-to-end:

1. Create a test pack with a `docs/` directory containing files no component references; `mcs pack validate <path>` → expect warnings about unreferenced `docs/*` files.
2. Add `ignore: [docs/]` to the manifest; `mcs pack validate <path>` → expect no warnings for `docs/`.
3. Add `ignore: [techpack.yaml]` → `mcs pack validate <path>` → expect a hard error mentioning the entry is not allowed.
4. Add `ignore: [hooks/handler.sh]` where the manifest references that file → expect the same hard error.
5. Add `ignore: [hooks/*]` (glob) where the manifest references `hooks/handler.sh` → expect the hard error (glob-aware rejection).
6. Install the (clean) pack and push a `docs/`-only commit upstream. Bust `~/.mcs/update-check.json`; run `mcs doctor` → expect no notification.
7. Edit the installed pack's `techpack.yaml` to add `ignore: [docs/]` (don't bust the cache); run `mcs doctor` again → expect the cache to invalidate and a fresh check to run.

<details>
<summary>Checklist for engine changes</summary>

- [x] Docs updated if behavior changed (`docs/techpack-schema.md`, `docs/creating-tech-packs.md`, `skills/techpack-creator/SKILL.md`, `skills/techpack-creator/references/techpack-schema.md`)

</details>