### PR TITLE
#338 Phase 3: Remediation hint in mcs pack validate

### DIFF
--- a/Sources/mcs/ExternalPack/PackHeuristics.swift
+++ b/Sources/mcs/ExternalPack/PackHeuristics.swift
@@ -25,10 +25,9 @@ enum PackHeuristics {
         findings += checkMCPDependencyGaps(components: components)
         findings += checkPythonModulePaths(components: components, packPath: packPath)
 
-        // Issue #338 Phase 3: when unreferenced-file warnings are present, point authors at
-        // the `ignore:` field so they can silence intentional non-material paths (docs/, examples/,
-        // assets) once and quiet both `mcs pack validate` and downstream update notifications.
-        if unreferenced.contains(where: { $0.severity == .warning && $0.message.contains("not referenced") }) {
+        // Surface the `ignore:` hint only when an actual unreferenced-file warning was emitted
+        // (not for the IO-failure warnings that share the same severity).
+        if unreferenced.contains(where: { $0.severity == .warning && $0.message.contains(Self.unreferencedMarker) }) {
             findings.append(Finding(
                 severity: .warning,
                 message: "Add intentional non-material paths (docs/, examples/, assets) to the"
@@ -38,6 +37,10 @@ enum PackHeuristics {
 
         return findings
     }
+
+    /// Sentinel substring shared between the `unreferenced file` warning emitters and the hint
+    /// detector in `check(...)`. Keep the two emit sites and the detector aligned.
+    static let unreferencedMarker = "is not referenced"
 
     // MARK: - Individual Checks
 
@@ -187,7 +190,7 @@ enum PackHeuristics {
                 if isIgnoredByManifest(relativePath, manifest: manifest) { continue }
                 findings.append(Finding(
                     severity: .warning,
-                    message: "\(relativePath) is not referenced by any component or template"
+                    message: "\(relativePath) \(Self.unreferencedMarker) by any component or template"
                 ))
             }
         }
@@ -253,7 +256,7 @@ enum PackHeuristics {
             if !infrastructureFiles.contains(name), !referencedRootFiles.contains(name) {
                 findings.append(Finding(
                     severity: .warning,
-                    message: "\(name) is not referenced by any component"
+                    message: "\(name) \(Self.unreferencedMarker) by any component"
                 ))
             }
         }

--- a/Sources/mcs/ExternalPack/PackHeuristics.swift
+++ b/Sources/mcs/ExternalPack/PackHeuristics.swift
@@ -253,7 +253,9 @@ enum PackHeuristics {
             guard fm.fileExists(atPath: itemURL.path, isDirectory: &isDir), !isDir.boolValue else { continue }
 
             let name = itemURL.lastPathComponent
-            if !infrastructureFiles.contains(name), !referencedRootFiles.contains(name) {
+            if !infrastructureFiles.contains(name),
+               !referencedRootFiles.contains(name),
+               !isIgnoredByManifest(name, manifest: manifest) {
                 findings.append(Finding(
                     severity: .warning,
                     message: "\(name) \(Self.unreferencedMarker) by any component"

--- a/Sources/mcs/ExternalPack/PackHeuristics.swift
+++ b/Sources/mcs/ExternalPack/PackHeuristics.swift
@@ -19,10 +19,22 @@ enum PackHeuristics {
         findings += checkEmptyPack(manifest: manifest)
         findings += checkRootSourceCopy(components: components)
         findings += checkSettingsFileSources(components: components, packPath: packPath)
-        findings += checkUnreferencedFiles(manifest: manifest, packPath: packPath)
-        findings += checkRootLevelContentFiles(manifest: manifest, packPath: packPath)
+        let unreferenced = checkUnreferencedFiles(manifest: manifest, packPath: packPath)
+            + checkRootLevelContentFiles(manifest: manifest, packPath: packPath)
+        findings += unreferenced
         findings += checkMCPDependencyGaps(components: components)
         findings += checkPythonModulePaths(components: components, packPath: packPath)
+
+        // Issue #338 Phase 3: when unreferenced-file warnings are present, point authors at
+        // the `ignore:` field so they can silence intentional non-material paths (docs/, examples/,
+        // assets) once and quiet both `mcs pack validate` and downstream update notifications.
+        if unreferenced.contains(where: { $0.severity == .warning && $0.message.contains("not referenced") }) {
+            findings.append(Finding(
+                severity: .warning,
+                message: "Add intentional non-material paths (docs/, examples/, assets) to the"
+                    + " `ignore:` field in techpack.yaml to silence these warnings."
+            ))
+        }
 
         return findings
     }

--- a/Tests/MCSTests/PackHeuristicsTests.swift
+++ b/Tests/MCSTests/PackHeuristicsTests.swift
@@ -5,7 +5,8 @@ import Testing
 struct PackHeuristicsTests {
     private func minimalManifest(
         identifier: String = "test-pack",
-        components: [ExternalComponentDefinition]? = nil
+        components: [ExternalComponentDefinition]? = nil,
+        ignore: [String]? = nil
     ) -> ExternalPackManifest {
         ExternalPackManifest(
             schemaVersion: 1,
@@ -19,7 +20,7 @@ struct PackHeuristicsTests {
             prompts: nil,
             configureProject: nil,
             supplementaryDoctorChecks: nil,
-            ignore: nil
+            ignore: ignore
         )
     }
 
@@ -812,7 +813,7 @@ struct PackHeuristicsTests {
         #expect(!PackHeuristics.isIgnoredByManifest("docs/guide.md", manifest: manifest))
     }
 
-    // MARK: - ignore: remediation hint (issue #338 Phase 3)
+    // MARK: - ignore: remediation hint
 
     @Test("Unreferenced files trigger the ignore: remediation hint")
     func unreferencedFilesEmitHint() throws {
@@ -870,13 +871,7 @@ struct PackHeuristicsTests {
             atomically: true, encoding: .utf8
         )
 
-        let manifest = ExternalPackManifest(
-            schemaVersion: 1,
-            identifier: "test-pack",
-            displayName: "Test Pack",
-            description: "test",
-            author: nil,
-            minMCSVersion: nil,
+        let manifest = minimalManifest(
             components: [
                 ExternalComponentDefinition(
                     id: "test-pack.brew",
@@ -886,10 +881,6 @@ struct PackHeuristicsTests {
                     installAction: .brewInstall(package: "git")
                 ),
             ],
-            templates: nil,
-            prompts: nil,
-            configureProject: nil,
-            supplementaryDoctorChecks: nil,
             ignore: ["docs/"]
         )
         let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)

--- a/Tests/MCSTests/PackHeuristicsTests.swift
+++ b/Tests/MCSTests/PackHeuristicsTests.swift
@@ -811,4 +811,88 @@ struct PackHeuristicsTests {
         let manifest = minimalManifest()
         #expect(!PackHeuristics.isIgnoredByManifest("docs/guide.md", manifest: manifest))
     }
+
+    // MARK: - ignore: remediation hint (issue #338 Phase 3)
+
+    @Test("Unreferenced files trigger the ignore: remediation hint")
+    func unreferencedFilesEmitHint() throws {
+        let tmpDir = try makeTmpDir(label: "heuristics-hint")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let docsDir = tmpDir.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
+        try "# Guide".write(
+            to: docsDir.appendingPathComponent("guide.md"),
+            atomically: true, encoding: .utf8
+        )
+
+        let manifest = minimalManifest(components: [
+            ExternalComponentDefinition(
+                id: "test-pack.brew",
+                displayName: "Brew",
+                description: "package",
+                type: .brewPackage,
+                installAction: .brewInstall(package: "git")
+            ),
+        ])
+        let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
+        #expect(findings.contains { $0.message.contains("Add intentional non-material paths") })
+    }
+
+    @Test("No unreferenced files → no remediation hint")
+    func noUnreferencedFilesNoHint() throws {
+        let tmpDir = try makeTmpDir(label: "heuristics-no-hint")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Only the techpack.yaml-equivalent root content; no extra files.
+        let manifest = minimalManifest(components: [
+            ExternalComponentDefinition(
+                id: "test-pack.brew",
+                displayName: "Brew",
+                description: "package",
+                type: .brewPackage,
+                installAction: .brewInstall(package: "git")
+            ),
+        ])
+        let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
+        #expect(!findings.contains { $0.message.contains("Add intentional non-material paths") })
+    }
+
+    @Test("ignore: silencing all unreferenced files removes the hint")
+    func ignoreSilencesHint() throws {
+        let tmpDir = try makeTmpDir(label: "heuristics-hint-ignored")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let docsDir = tmpDir.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
+        try "# Guide".write(
+            to: docsDir.appendingPathComponent("guide.md"),
+            atomically: true, encoding: .utf8
+        )
+
+        let manifest = ExternalPackManifest(
+            schemaVersion: 1,
+            identifier: "test-pack",
+            displayName: "Test Pack",
+            description: "test",
+            author: nil,
+            minMCSVersion: nil,
+            components: [
+                ExternalComponentDefinition(
+                    id: "test-pack.brew",
+                    displayName: "Brew",
+                    description: "package",
+                    type: .brewPackage,
+                    installAction: .brewInstall(package: "git")
+                ),
+            ],
+            templates: nil,
+            prompts: nil,
+            configureProject: nil,
+            supplementaryDoctorChecks: nil,
+            ignore: ["docs/"]
+        )
+        let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
+        #expect(!findings.contains { $0.message.contains("Add intentional non-material paths") })
+    }
 }

--- a/Tests/MCSTests/PackHeuristicsTests.swift
+++ b/Tests/MCSTests/PackHeuristicsTests.swift
@@ -886,4 +886,27 @@ struct PackHeuristicsTests {
         let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
         #expect(!findings.contains { $0.message.contains("Add intentional non-material paths") })
     }
+
+    @Test("ignore: silences root-level unreferenced file warnings")
+    func ignoreSilencesRootLevelUnreferencedFile() throws {
+        let tmpDir = try makeTmpDir(label: "heuristics-root-ignore")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: tmpDir.appendingPathComponent("screenshot.png"))
+
+        let manifest = minimalManifest(
+            components: [
+                ExternalComponentDefinition(
+                    id: "test-pack.brew",
+                    displayName: "Brew",
+                    description: "package",
+                    type: .brewPackage,
+                    installAction: .brewInstall(package: "git")
+                ),
+            ],
+            ignore: ["screenshot.png"]
+        )
+        let findings = PackHeuristics.check(manifest: manifest, packPath: tmpDir)
+        #expect(!findings.contains { $0.message.contains("screenshot.png") && $0.message.contains(PackHeuristics.unreferencedMarker) })
+    }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,6 +106,8 @@ mcs pack validate ios            # Validate an installed pack by identifier
 
 Structural errors always cause exit code 1 and stop further analysis. Heuristic errors also cause exit code 1. Warnings are advisory and do not affect the exit code.
 
+When unreferenced-file warnings appear, the command also emits a remediation hint pointing authors at the manifest's `ignore:` field (see [Schema Reference](techpack-schema.md#the-ignore-field)) — adding intentional non-material paths there silences both the validation warnings and downstream `mcs check-updates` notifications for commits limited to those paths.
+
 ## `mcs doctor`
 
 Diagnose installation health with multi-layer checks.


### PR DESCRIPTION
## Summary

Close the discovery loop for the `ignore:` field shipped in #344. When `mcs pack validate` flags unreferenced files, append a hint pointing authors at the field — they learn about the suppression mechanism through the warning that motivated them to look, instead of having to find the schema reference first.

**Stacked on #344** — review and merge that PR first; this branch's base is `bruno/338-ignore-field`. Will retarget to `main` once #343 and #344 land.

## Changes

- When `mcs pack validate` produces at least one "not referenced" warning, the command now also emits a single advisory pointing at the manifest's `ignore:` field. The hint quotes the field name and lists typical non-material targets (docs, examples, assets).
- The hint is suppressed when no unreferenced files exist, and when an author has already added `ignore:` entries that cover every unreferenced path — authors who've configured the field correctly don't see redundant nudging.
- `docs/cli.md` describes the hint behavior in the `mcs pack validate` section, with a link to the schema reference's `ignore:` subsection.

## Test plan

- [ ] `swift test` passes locally
- [ ] `swiftformat --lint .` and `swiftlint` pass without violations
- [ ] Affected commands verified with a real pack (e.g. `mcs sync`, `mcs doctor`)

Manual:

1. Create a test pack with a `docs/` directory containing files no component references; `mcs pack validate <path>` → expect the per-file warnings AND the new hint about `ignore:`.
2. Add `ignore: [docs/]` to the manifest; `mcs pack validate <path>` → expect no warnings AND no hint.
3. Run `mcs pack validate` on a clean pack with no unreferenced files at all → expect no hint.

<details>
<summary>Checklist for engine changes</summary>

- [ ] Docs updated if behavior changed (`CLAUDE.md`, `docs/`, `techpack.yaml` schema in `ExternalPackManifest.swift`)

</details>