### PR TITLE
Add 'mcs update' multi-scope refresh command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,13 @@ mcs sync --dry-run               # Preview what would change
 mcs sync --customize             # Per-pack component selection
 mcs sync --global                # Sync global scope (MCP servers, brew, plugins to ~/.claude/)
 mcs sync --lock                  # Checkout locked versions from mcs.lock.yaml
-mcs sync --update                # Fetch latest versions and update mcs.lock.yaml
+mcs sync --update                # [DEPRECATED — use 'mcs update'] Fetch latest and force-write mcs.lock.yaml
+mcs update                       # Fetch latest pack versions and re-apply across every configured scope
+mcs update --pack ios            # Refresh specific packs only (repeatable)
+mcs update --global              # Refresh only the global scope
+mcs update --project             # Refresh only the current project's scope
+mcs update --all-projects        # Refresh global + every project tracked in ~/.mcs/projects.yaml (asks confirmation)
+mcs update --dry-run             # Preview what would change
 mcs doctor                       # Diagnose installation health
 mcs doctor --fix                 # Diagnose and auto-fix issues
 mcs doctor --pack ios            # Only check a specific pack
@@ -35,7 +41,7 @@ mcs pack add <url> --preview     # Preview pack contents without installing
 mcs pack remove <name>           # Remove an external tech pack
 mcs pack remove <name> --force   # Remove without confirmation
 mcs pack list                    # List registered external packs
-mcs pack update [name]           # Update pack(s) to latest version (skips local packs)
+mcs pack update [name]           # [DEPRECATED — use 'mcs update'] Refresh pack registry only (no re-apply)
 mcs pack validate [source]       # Validate a tech pack (path, identifier, or current directory)
 mcs cleanup                      # Find and delete backup files
 mcs cleanup --force              # Delete backups without confirmation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,6 @@ mcs sync --global                # Sync global scope (MCP servers, brew, plugins
 mcs sync --lock                  # Checkout locked versions from mcs.lock.yaml
 mcs sync --update                # [DEPRECATED — use 'mcs update'] Fetch latest and force-write mcs.lock.yaml
 mcs update                       # Fetch latest pack versions and re-apply across every configured scope
-mcs update --pack ios            # Refresh specific packs only (repeatable)
 mcs update --global              # Refresh only the global scope
 mcs update --project             # Refresh only the current project's scope
 mcs update --all-projects        # Refresh global + every project tracked in ~/.mcs/projects.yaml (asks confirmation)
@@ -41,7 +40,7 @@ mcs pack add <url> --preview     # Preview pack contents without installing
 mcs pack remove <name>           # Remove an external tech pack
 mcs pack remove <name> --force   # Remove without confirmation
 mcs pack list                    # List registered external packs
-mcs pack update [name]           # [DEPRECATED — use 'mcs update'] Refresh pack registry only (no re-apply)
+mcs pack update [name]           # Refresh pack registry only (low-level fetch; use 'mcs update' for fetch + apply)
 mcs pack validate [source]       # Validate a tech pack (path, identifier, or current directory)
 mcs cleanup                      # Find and delete backup files
 mcs cleanup --force              # Delete backups without confirmation

--- a/Sources/mcs/CLI.swift
+++ b/Sources/mcs/CLI.swift
@@ -14,6 +14,7 @@ struct MCS: ParsableCommand {
         version: MCSVersion.current,
         subcommands: [
             SyncCommand.self,
+            UpdateCommand.self,
             DoctorCommand.self,
             CleanupCommand.self,
             PackCommand.self,

--- a/Sources/mcs/Commands/PackCommand.swift
+++ b/Sources/mcs/Commands/PackCommand.swift
@@ -625,6 +625,8 @@ struct UpdatePack: LockedCommand {
         let ctx = PackCommandContext()
         defer { MCSAnalytics.trackCommand(.packUpdate) }
 
+        ctx.output.warn("'mcs pack update' is deprecated. Use 'mcs update' to fetch and re-apply across all configured scopes in one step.")
+
         let updater = PackUpdater(
             fetcher: PackFetcher(shell: ctx.shell, output: ctx.output, packsDirectory: ctx.env.packsDirectory),
             trustManager: PackTrustManager(output: ctx.output),
@@ -677,7 +679,7 @@ struct UpdatePack: LockedCommand {
             case let .updated(updatedEntry):
                 ctx.registry.register(updatedEntry, in: &updatedData)
                 updatedCount += 1
-                ctx.output.success("\(entry.displayName): updated (\(updatedEntry.commitSHA.prefix(7)))")
+                ctx.output.success("\(entry.displayName): updated (\(updatedEntry.shortSHA))")
             case let .skipped(reason):
                 ctx.output.warn("\(entry.identifier): \(reason)")
             }
@@ -692,7 +694,7 @@ struct UpdatePack: LockedCommand {
                 throw ExitCode.failure
             }
             ctx.output.plain("")
-            ctx.output.info("Run 'mcs sync' to apply updated pack components.")
+            ctx.output.info("Run 'mcs update' to apply updates across all configured scopes.")
         }
     }
 }

--- a/Sources/mcs/Commands/PackCommand.swift
+++ b/Sources/mcs/Commands/PackCommand.swift
@@ -625,8 +625,6 @@ struct UpdatePack: LockedCommand {
         let ctx = PackCommandContext()
         defer { MCSAnalytics.trackCommand(.packUpdate) }
 
-        ctx.output.warn("'mcs pack update' is deprecated. Use 'mcs update' to fetch and re-apply across all configured scopes in one step.")
-
         let updater = PackUpdater(
             fetcher: PackFetcher(shell: ctx.shell, output: ctx.output, packsDirectory: ctx.env.packsDirectory),
             trustManager: PackTrustManager(output: ctx.output),

--- a/Sources/mcs/Commands/SyncCommand.swift
+++ b/Sources/mcs/Commands/SyncCommand.swift
@@ -53,6 +53,10 @@ struct SyncCommand: LockedCommand {
 
         // Handle --update: fetch latest for all packs before loading
         if update {
+            output.warn(
+                "'mcs sync --update' is deprecated. Use 'mcs update' to fetch and re-apply across all configured scopes; "
+                    + "combine with 'mcs config set generate-lockfile true' if you want a lockfile."
+            )
             let lockOps = LockfileOperations(environment: env, output: output, shell: shell)
             try lockOps.updatePacks()
         }

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -95,6 +95,7 @@ struct UpdateCommand: LockedCommand {
 
         try runReapplyPhase(
             runs: runs,
+            requestedPackIDs: Set(pack),
             skippedPackIDs: skippedPackIDs,
             registry: techPackRegistry,
             env: env,
@@ -288,6 +289,7 @@ struct UpdateCommand: LockedCommand {
 
     private func runReapplyPhase(
         runs: [UpdateScopeResolver.ScopeRun],
+        requestedPackIDs: Set<String>,
         skippedPackIDs: Set<String>,
         registry: TechPackRegistry,
         env: Environment,
@@ -297,8 +299,24 @@ struct UpdateCommand: LockedCommand {
         for run in runs {
             output.header(run.label)
 
-            let packIDs = run.configuredPackIDs.subtracting(skippedPackIDs)
-            let packs: [any TechPack] = packIDs.compactMap { registry.pack(for: $0) }
+            let scoped = requestedPackIDs.isEmpty
+                ? run.configuredPackIDs
+                : run.configuredPackIDs.intersection(requestedPackIDs)
+            let packIDs = scoped.subtracting(skippedPackIDs)
+
+            var packs: [any TechPack] = []
+            var unresolved: [String] = []
+            for packID in packIDs {
+                if let pack = registry.pack(for: packID) {
+                    packs.append(pack)
+                } else {
+                    unresolved.append(packID)
+                }
+            }
+
+            for packID in unresolved.sorted() {
+                output.warn("  \(packID): tracked in state but missing from pack registry — skipping. Run 'mcs pack add' to restore it.")
+            }
 
             guard !packs.isEmpty else {
                 output.info("No packs to refresh in this scope.")

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -1,12 +1,10 @@
 import ArgumentParser
 import Foundation
 
-/// Refresh configured packs across every scope they are installed in.
-///
-/// Fetches latest pack contents (with trust verification), then re-applies the
-/// existing configured set in both the global scope and the current project's scope.
-/// Does not add or remove packs — that stays the job of `mcs sync`. Lockfile writes
-/// are gated by `generate-lockfile`, unlike `mcs sync --update` which always writes.
+/// Refresh-only orchestration: fetch latest pack contents (with trust verification),
+/// then re-apply the existing configured set in both the global scope and the current
+/// project's scope. Does not add or remove packs (use `mcs sync`). Lockfile writes are
+/// gated by `generate-lockfile`, unlike `mcs sync --update` which force-writes.
 struct UpdateCommand: LockedCommand {
     static let configuration = CommandConfiguration(
         commandName: "update",
@@ -15,9 +13,6 @@ struct UpdateCommand: LockedCommand {
 
     @Argument(help: "Path to the project directory (defaults to current directory)")
     var path: String?
-
-    @Option(name: .long, help: "Pack identifier to update (repeatable). Defaults to all configured packs.")
-    var pack: [String] = []
 
     @Flag(name: .long, help: "Only refresh the global scope")
     var global: Bool = false
@@ -66,17 +61,12 @@ struct UpdateCommand: LockedCommand {
         let configuredAcrossScopes = runs.reduce(into: Set<String>()) {
             $0.formUnion($1.configuredPackIDs)
         }
-        let packsToUpdate = try resolveTargetPackIDs(
-            requestedPackIDs: pack,
-            configured: configuredAcrossScopes,
-            output: output
-        )
 
         let registryFile = PackRegistryFile(path: env.packsRegistry)
         let registryData = try registryFile.load()
 
         let (updatedRegistryData, anyUpdated, skippedPackIDs) = try runUpdatePhase(
-            packIDsToUpdate: packsToUpdate,
+            packIDsToUpdate: configuredAcrossScopes,
             registryFile: registryFile,
             registryData: registryData,
             env: env,
@@ -95,7 +85,6 @@ struct UpdateCommand: LockedCommand {
 
         try runReapplyPhase(
             runs: runs,
-            requestedPackIDs: Set(pack),
             skippedPackIDs: skippedPackIDs,
             registry: techPackRegistry,
             env: env,
@@ -112,9 +101,7 @@ struct UpdateCommand: LockedCommand {
 
     // MARK: - Helpers
 
-    /// Single scope flag enum keeps the validate + resolve paths in lockstep so
-    /// adding a new scope flag updates one site, not three.
-    private enum ScopeFlag: String, CaseIterable {
+    private enum ScopeFlag: String {
         case global = "--global"
         case project = "--project"
         case allProjects = "--all-projects"
@@ -155,8 +142,6 @@ struct UpdateCommand: LockedCommand {
         }
     }
 
-    /// Confirm before fanning out to every project. Skipped on `--dry-run` (read-only)
-    /// and in non-interactive runs (where there's no one to confirm).
     private func confirmFanOut(
         runs: [UpdateScopeResolver.ScopeRun],
         output: CLIOutput
@@ -204,27 +189,6 @@ struct UpdateCommand: LockedCommand {
             URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
         }
         return ProjectDetector.findProjectRoot(from: target)
-    }
-
-    private func resolveTargetPackIDs(
-        requestedPackIDs: [String],
-        configured: Set<String>,
-        output: CLIOutput
-    ) throws -> Set<String> {
-        guard !requestedPackIDs.isEmpty else { return configured }
-
-        let requested = Set(requestedPackIDs)
-        let unknown = requested.subtracting(configured)
-        for id in unknown.sorted() {
-            output.warn("Pack '\(id)' is not configured in any scope being updated — skipping.")
-        }
-
-        let intersection = requested.intersection(configured)
-        guard !intersection.isEmpty else {
-            output.error("No matching configured packs found.")
-            throw ExitCode.failure
-        }
-        return intersection
     }
 
     private func runUpdatePhase(
@@ -289,7 +253,6 @@ struct UpdateCommand: LockedCommand {
 
     private func runReapplyPhase(
         runs: [UpdateScopeResolver.ScopeRun],
-        requestedPackIDs: Set<String>,
         skippedPackIDs: Set<String>,
         registry: TechPackRegistry,
         env: Environment,
@@ -299,10 +262,7 @@ struct UpdateCommand: LockedCommand {
         for run in runs {
             output.header(run.label)
 
-            let scoped = requestedPackIDs.isEmpty
-                ? run.configuredPackIDs
-                : run.configuredPackIDs.intersection(requestedPackIDs)
-            let packIDs = scoped.subtracting(skippedPackIDs)
+            let packIDs = run.configuredPackIDs.subtracting(skippedPackIDs)
 
             var packs: [any TechPack] = []
             var unresolved: [String] = []

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -132,7 +132,7 @@ struct UpdateCommand: LockedCommand {
             return (.globalOnly, nil)
         case .project:
             guard let root = detectProjectRoot() else {
-                output.error("--project specified but no project root detected at \(FileManager.default.currentDirectoryPath).")
+                output.error("--project specified but no project root detected at \(targetPath.path).")
                 output.plain("  cd into a project directory, pass a path, or omit --project.")
                 throw ExitCode.failure
             }
@@ -182,13 +182,16 @@ struct UpdateCommand: LockedCommand {
         }
     }
 
-    private func detectProjectRoot() -> URL? {
-        let target = if let path {
+    private var targetPath: URL {
+        if let path {
             URL(fileURLWithPath: path)
         } else {
             URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
         }
-        return ProjectDetector.findProjectRoot(from: target)
+    }
+
+    private func detectProjectRoot() -> URL? {
+        ProjectDetector.findProjectRoot(from: targetPath)
     }
 
     private func runUpdatePhase(
@@ -262,7 +265,7 @@ struct UpdateCommand: LockedCommand {
         for run in runs {
             output.header(run.label)
 
-            let packIDs = run.configuredPackIDs.subtracting(skippedPackIDs)
+            let packIDs = run.configuredPackIDs.subtracting(skippedPackIDs).sorted()
 
             var packs: [any TechPack] = []
             var unresolved: [String] = []
@@ -274,7 +277,7 @@ struct UpdateCommand: LockedCommand {
                 }
             }
 
-            for packID in unresolved.sorted() {
+            for packID in unresolved {
                 output.warn("  \(packID): tracked in state but missing from pack registry — skipping. Run 'mcs pack add' to restore it.")
             }
 

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -1,0 +1,350 @@
+import ArgumentParser
+import Foundation
+
+/// Refresh configured packs across every scope they are installed in.
+///
+/// Fetches latest pack contents (with trust verification), then re-applies the
+/// existing configured set in both the global scope and the current project's scope.
+/// Does not add or remove packs — that stays the job of `mcs sync`. Lockfile writes
+/// are gated by `generate-lockfile`, unlike `mcs sync --update` which always writes.
+struct UpdateCommand: LockedCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "update",
+        abstract: "Fetch latest pack versions and re-apply across configured scopes"
+    )
+
+    @Argument(help: "Path to the project directory (defaults to current directory)")
+    var path: String?
+
+    @Option(name: .long, help: "Pack identifier to update (repeatable). Defaults to all configured packs.")
+    var pack: [String] = []
+
+    @Flag(name: .long, help: "Only refresh the global scope")
+    var global: Bool = false
+
+    @Flag(name: .long, help: "Only refresh the current project's scope")
+    var project: Bool = false
+
+    @Flag(name: .customLong("all-projects"), help: "Refresh every project in the index plus the global scope (fan out machine-wide)")
+    var allProjects: Bool = false
+
+    @Flag(name: .long, help: "Show what would change without making any modifications")
+    var dryRun = false
+
+    var skipLock: Bool {
+        dryRun
+    }
+
+    func perform() throws {
+        let env = Environment()
+        let output = CLIOutput()
+        MCSAnalytics.initialize(env: env, output: output)
+        defer { MCSAnalytics.trackCommand(.update) }
+        let shell = ShellRunner(environment: env)
+
+        guard ensureClaudeCLI(shell: shell, environment: env, output: output) else {
+            throw ExitCode.failure
+        }
+
+        let (filter, projectRoot) = try resolveScopeSelection(output: output)
+
+        let resolver = UpdateScopeResolver(environment: env, output: output)
+        let runs = try resolver.resolve(filter: filter, projectRoot: projectRoot, dryRun: dryRun)
+
+        guard !runs.isEmpty else {
+            output.info("Nothing to update — no scopes have configured packs.")
+            return
+        }
+
+        if allProjects, !confirmFanOut(runs: runs, output: output) {
+            output.info("Update cancelled.")
+            return
+        }
+
+        warnIfProjectScopeMissing(filter: filter, projectRoot: projectRoot, runs: runs, output: output)
+
+        let configuredAcrossScopes = runs.reduce(into: Set<String>()) {
+            $0.formUnion($1.configuredPackIDs)
+        }
+        let packsToUpdate = try resolveTargetPackIDs(
+            requestedPackIDs: pack,
+            configured: configuredAcrossScopes,
+            output: output
+        )
+
+        let registryFile = PackRegistryFile(path: env.packsRegistry)
+        let registryData = try registryFile.load()
+
+        let (updatedRegistryData, anyUpdated, skippedPackIDs) = try runUpdatePhase(
+            packIDsToUpdate: packsToUpdate,
+            registryFile: registryFile,
+            registryData: registryData,
+            env: env,
+            shell: shell,
+            output: output
+        )
+
+        if !dryRun, anyUpdated {
+            try registryFile.save(updatedRegistryData)
+        }
+
+        let techPackRegistry = TechPackRegistry.loadWithExternalPacks(
+            environment: env,
+            output: output
+        )
+
+        try runReapplyPhase(
+            runs: runs,
+            skippedPackIDs: skippedPackIDs,
+            registry: techPackRegistry,
+            env: env,
+            shell: shell,
+            output: output
+        )
+
+        try runLockfilePhase(runs: runs, env: env, shell: shell, output: output)
+
+        if !dryRun {
+            UpdateChecker.checkAndPrint(env: env, shell: shell, output: output)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Single scope flag enum keeps the validate + resolve paths in lockstep so
+    /// adding a new scope flag updates one site, not three.
+    private enum ScopeFlag: String, CaseIterable {
+        case global = "--global"
+        case project = "--project"
+        case allProjects = "--all-projects"
+    }
+
+    private var activeScopeFlags: [ScopeFlag] {
+        var flags: [ScopeFlag] = []
+        if global { flags.append(.global) }
+        if project { flags.append(.project) }
+        if allProjects { flags.append(.allProjects) }
+        return flags
+    }
+
+    private func resolveScopeSelection(
+        output: CLIOutput
+    ) throws -> (UpdateScopeResolver.Filter, URL?) {
+        let active = activeScopeFlags
+        guard active.count <= 1 else {
+            let names = active.map(\.rawValue).joined(separator: ", ")
+            output.error("\(names) are mutually exclusive.")
+            throw ExitCode.failure
+        }
+
+        switch active.first {
+        case .allProjects:
+            return (.everywhere, nil)
+        case .global:
+            return (.globalOnly, nil)
+        case .project:
+            guard let root = detectProjectRoot() else {
+                output.error("--project specified but no project root detected at \(FileManager.default.currentDirectoryPath).")
+                output.plain("  cd into a project directory, pass a path, or omit --project.")
+                throw ExitCode.failure
+            }
+            return (.projectOnly, root)
+        case .none:
+            return (.all, detectProjectRoot())
+        }
+    }
+
+    /// Confirm before fanning out to every project. Skipped on `--dry-run` (read-only)
+    /// and in non-interactive runs (where there's no one to confirm).
+    private func confirmFanOut(
+        runs: [UpdateScopeResolver.ScopeRun],
+        output: CLIOutput
+    ) -> Bool {
+        guard !dryRun, output.hasInteractiveStdin else { return true }
+
+        let projectRuns = runs.filter { !$0.isGlobal }
+        guard !projectRuns.isEmpty else { return true }
+
+        output.warn("--all-projects will refresh \(projectRuns.count) project(s):")
+        for run in projectRuns {
+            if let projectPath = run.projectPath {
+                output.plain("  • \(projectPath.path)")
+            }
+        }
+        output.plain("")
+        output.plain("  Each project's pack-defined hooks will run with that project as cwd.")
+        output.plain("  Uncommitted changes in those projects may be overwritten by managed files.")
+        output.plain("")
+        return output.askYesNo("Proceed?", default: false)
+    }
+
+    private func warnIfProjectScopeMissing(
+        filter: UpdateScopeResolver.Filter,
+        projectRoot: URL?,
+        runs: [UpdateScopeResolver.ScopeRun],
+        output: CLIOutput
+    ) {
+        guard filter == .all else { return }
+        guard !runs.contains(where: { !$0.isGlobal }) else { return }
+
+        if let projectRoot {
+            output.warn("Project at \(projectRoot.path) has no configured packs — only refreshing the global scope.")
+            output.plain("  Run 'mcs sync' inside the project to configure packs there first.")
+        } else {
+            output.warn("Not in a project directory — only refreshing the global scope.")
+            output.plain("  cd into a project to also refresh its packs.")
+        }
+    }
+
+    private func detectProjectRoot() -> URL? {
+        let target = if let path {
+            URL(fileURLWithPath: path)
+        } else {
+            URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        }
+        return ProjectDetector.findProjectRoot(from: target)
+    }
+
+    private func resolveTargetPackIDs(
+        requestedPackIDs: [String],
+        configured: Set<String>,
+        output: CLIOutput
+    ) throws -> Set<String> {
+        guard !requestedPackIDs.isEmpty else { return configured }
+
+        let requested = Set(requestedPackIDs)
+        let unknown = requested.subtracting(configured)
+        for id in unknown.sorted() {
+            output.warn("Pack '\(id)' is not configured in any scope being updated — skipping.")
+        }
+
+        let intersection = requested.intersection(configured)
+        guard !intersection.isEmpty else {
+            output.error("No matching configured packs found.")
+            throw ExitCode.failure
+        }
+        return intersection
+    }
+
+    private func runUpdatePhase(
+        packIDsToUpdate: Set<String>,
+        registryFile: PackRegistryFile,
+        registryData: PackRegistryFile.RegistryData,
+        env: Environment,
+        shell: ShellRunner,
+        output: CLIOutput
+    ) throws -> (data: PackRegistryFile.RegistryData, anyUpdated: Bool, skipped: Set<String>) {
+        var updatedData = registryData
+        var anyUpdated = false
+        var skipped: Set<String> = []
+
+        let entries = registryData.packs.filter { packIDsToUpdate.contains($0.identifier) }
+        guard !entries.isEmpty else { return (updatedData, anyUpdated, skipped) }
+
+        output.header("Updating packs")
+
+        if dryRun {
+            for entry in entries {
+                output.dimmed("  \(entry.displayName): would check for updates")
+            }
+            return (updatedData, anyUpdated, skipped)
+        }
+
+        let updater = PackUpdater(
+            fetcher: PackFetcher(shell: shell, output: output, packsDirectory: env.packsDirectory),
+            trustManager: PackTrustManager(output: output),
+            environment: env,
+            output: output
+        )
+
+        for entry in entries {
+            if entry.isLocalPack {
+                output.dimmed("  \(entry.displayName): local pack (skipped)")
+                continue
+            }
+
+            guard let packPath = entry.resolvedPath(packsDirectory: env.packsDirectory) else {
+                output.warn("  \(entry.identifier): invalid path — skipping")
+                skipped.insert(entry.identifier)
+                continue
+            }
+
+            let result = updater.updateGitPack(entry: entry, packPath: packPath, registry: registryFile)
+            switch result {
+            case .alreadyUpToDate:
+                output.dimmed("  \(entry.displayName): already up to date")
+            case let .updated(updatedEntry):
+                registryFile.register(updatedEntry, in: &updatedData)
+                anyUpdated = true
+                output.success("  \(entry.displayName): \(entry.shortSHA) → \(updatedEntry.shortSHA)")
+            case let .skipped(reason):
+                output.warn("  \(entry.identifier): \(reason) (will re-prompt on next 'mcs update')")
+                skipped.insert(entry.identifier)
+            }
+        }
+
+        return (updatedData, anyUpdated, skipped)
+    }
+
+    private func runReapplyPhase(
+        runs: [UpdateScopeResolver.ScopeRun],
+        skippedPackIDs: Set<String>,
+        registry: TechPackRegistry,
+        env: Environment,
+        shell: ShellRunner,
+        output: CLIOutput
+    ) throws {
+        for run in runs {
+            output.header(run.label)
+
+            let packIDs = run.configuredPackIDs.subtracting(skippedPackIDs)
+            let packs: [any TechPack] = packIDs.compactMap { registry.pack(for: $0) }
+
+            guard !packs.isEmpty else {
+                output.info("No packs to refresh in this scope.")
+                continue
+            }
+
+            let configurator = Configurator(
+                environment: env,
+                output: output,
+                shell: shell,
+                registry: registry,
+                strategy: run.strategy
+            )
+
+            if dryRun {
+                try configurator.dryRun(packs: packs)
+            } else {
+                try configurator.configure(
+                    packs: packs,
+                    confirmRemovals: false,
+                    excludedComponents: run.excludedComponents,
+                    reusePriorValuesSilently: true
+                )
+            }
+        }
+    }
+
+    private func runLockfilePhase(
+        runs: [UpdateScopeResolver.ScopeRun],
+        env: Environment,
+        shell: ShellRunner,
+        output: CLIOutput
+    ) throws {
+        guard !dryRun else { return }
+
+        let config = MCSConfig.load(from: env.mcsConfigFile, output: output)
+        let lockOps = LockfileOperations(environment: env, output: output, shell: shell)
+
+        for run in runs where !run.isGlobal {
+            guard let projectPath = run.projectPath else { continue }
+
+            if config.isLockfileGenerationEnabled {
+                try lockOps.writeLockfile(at: projectPath)
+            } else if config.isLockfileGenerationUnset {
+                try lockOps.reportDrift(at: projectPath)
+            }
+        }
+    }
+}

--- a/Sources/mcs/Core/ProjectIndex.swift
+++ b/Sources/mcs/Core/ProjectIndex.swift
@@ -18,6 +18,16 @@ struct ProjectIndex {
         var packs: [String]
         /// ISO 8601 timestamp of the last sync.
         var lastSynced: String
+
+        /// Whether this entry represents the global scope rather than a project.
+        var isGlobal: Bool {
+            path == ProjectIndex.globalSentinel
+        }
+
+        /// File URL for project entries. Returns `nil` for the global sentinel.
+        var url: URL? {
+            isGlobal ? nil : URL(fileURLWithPath: path)
+        }
     }
 
     struct IndexData: Codable {

--- a/Sources/mcs/Core/Telemetry.swift
+++ b/Sources/mcs/Core/Telemetry.swift
@@ -15,6 +15,7 @@ enum MCSAnalytics {
     /// Type-safe command names for telemetry signals.
     enum Command: String {
         case sync
+        case update
         case doctor
         case cleanup
         case packAdd = "pack.add"

--- a/Sources/mcs/Core/UpdateChecker.swift
+++ b/Sources/mcs/Core/UpdateChecker.swift
@@ -605,7 +605,7 @@ struct UpdateChecker {
                     let remote = String(pack.remoteSHA.prefix(7))
                     output.plain("         \u{2022} \(pack.displayName) (\(local) \u{2192} \(remote))")
                 }
-                output.plain("       Run 'mcs pack update' to update.")
+                output.plain("       Run 'mcs update' to update and re-apply across configured scopes.")
             }
         }
 
@@ -632,7 +632,7 @@ struct UpdateChecker {
             let noun = result.packUpdates.count == 1 ? "tech pack has" : "tech packs have"
             lines.append(
                 "- \(result.packUpdates.count) \(noun) updates available: \(names)."
-                    + " The user should run: mcs pack update"
+                    + " The user should run: mcs update"
             )
         }
         return lines.joined(separator: "\n")

--- a/Sources/mcs/ExternalPack/PackRegistryFile.swift
+++ b/Sources/mcs/ExternalPack/PackRegistryFile.swift
@@ -22,6 +22,11 @@ struct PackRegistryFile {
             isLocal ?? false
         }
 
+        /// 7-character short prefix of the commit SHA for display.
+        var shortSHA: String {
+            String(commitSHA.prefix(7))
+        }
+
         /// Resolve the on-disk path for this pack entry.
         /// Local packs store an absolute path; git packs store a path relative to `packsDirectory`.
         /// Returns `nil` if the local path is invalid or the git path escapes the packs directory.

--- a/Sources/mcs/Sync/Configurator.swift
+++ b/Sources/mcs/Sync/Configurator.swift
@@ -178,11 +178,16 @@ struct Configurator {
     /// - Parameter confirmRemovals: When `true`, prompt the user before removing packs.
     ///   Pass `false` for non-interactive paths (`--pack`, `--all`).
     /// - Parameter excludedComponents: Component IDs excluded per pack (packID -> Set<componentID>).
+    /// - Parameter reusePriorValuesSilently: When `true`, skip the interactive
+    ///   "Reuse these values?" gate even when stdin is a TTY — used by
+    ///   `mcs update`, where re-asking only makes sense for genuinely new prompts.
+    ///   Existing priors are silently reused; new prompts still execute.
     func configure(
         packs: [any TechPack],
         confirmRemovals: Bool = true,
         excludedComponents: [String: Set<String>] = [:],
-        customize: Bool = false
+        customize: Bool = false,
+        reusePriorValuesSilently: Bool = false
     ) throws {
         var state = try ProjectState(stateFile: scope.stateFile)
         let fsContext = strategy.makeCollisionContext(trackedFiles: state.allTrackedFiles)
@@ -238,7 +243,10 @@ struct Configurator {
         let priorResolvedValues = state.resolvedValues ?? [:]
 
         // 3–4b. Resolve all template/placeholder values upfront (single pass)
-        let allValues = try resolveAllValues(packs: packs, state: &state, customize: customize)
+        let allValues = try resolveAllValues(
+            packs: packs, state: &state, customize: customize,
+            reusePriorValuesSilently: reusePriorValuesSilently
+        )
 
         // 4c. Pre-load templates (single disk read per pack), filtering excluded dependencies
         let preloadedTemplates = preloadTemplates(
@@ -637,7 +645,8 @@ struct Configurator {
     private func resolveAllValues(
         packs: [any TechPack],
         state: inout ProjectState,
-        customize: Bool
+        customize: Bool,
+        reusePriorValuesSilently: Bool
     ) throws -> [String: String] {
         let priorValues = state.resolvedValues ?? [:]
         var allValues = strategy.resolveBuiltInValues(shell: shell, output: output)
@@ -655,7 +664,8 @@ struct Configurator {
         let seedFromPriors = decideSeedStrategy(
             reusableValues: reusableValues,
             newDeclaredKeys: newDeclaredKeys,
-            customize: customize
+            customize: customize,
+            reusePriorValuesSilently: reusePriorValuesSilently
         )
         if seedFromPriors {
             allValues.merge(reusableValues) { existing, _ in existing }
@@ -711,16 +721,25 @@ struct Configurator {
     /// added since last sync reuses old values and prompts only for the new ones.
     /// Interactive with only reusable prompts shows the key list (values masked —
     /// prompts often hold secrets) and gates on a single Y/n.
+    /// `reusePriorValuesSilently` (set by `mcs update`) collapses the interactive-only
+    /// branches into the same silent-reuse path used for non-interactive runs.
     private func decideSeedStrategy(
         reusableValues: [String: String],
         newDeclaredKeys: Set<String>,
-        customize: Bool
+        customize: Bool,
+        reusePriorValuesSilently: Bool
     ) -> Bool {
         guard !reusableValues.isEmpty else { return false }
         if customize { return false }
 
         if !output.hasInteractiveStdin {
             output.dimmed("Reusing \(reusableValues.count) previously configured value(s) from last sync.")
+            return true
+        }
+
+        if reusePriorValuesSilently {
+            let suffix = newDeclaredKeys.isEmpty ? "." : "; asking for \(newDeclaredKeys.count) new."
+            output.dimmed("Reusing \(reusableValues.count) previously configured value(s)\(suffix)")
             return true
         }
 

--- a/Sources/mcs/Sync/LockfileOperations.swift
+++ b/Sources/mcs/Sync/LockfileOperations.swift
@@ -117,7 +117,7 @@ struct LockfileOperations {
                 output.dimmed("  \(entry.identifier): already up to date")
             case let .updated(updatedEntry):
                 registryFile.register(updatedEntry, in: &updatedData)
-                output.success("  \(entry.identifier): updated (\(String(updatedEntry.commitSHA.prefix(7))))")
+                output.success("  \(entry.identifier): updated (\(updatedEntry.shortSHA))")
             case let .skipped(reason):
                 output.warn("  \(entry.identifier): \(reason)")
             }

--- a/Sources/mcs/Sync/UpdateScopeResolver.swift
+++ b/Sources/mcs/Sync/UpdateScopeResolver.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Resolves which scopes `mcs update` should refresh.
+///
+/// Reads `~/.mcs/projects.yaml` and the per-scope state files to enumerate every
+/// place that has configured packs. Returns one entry per scope to refresh, with
+/// the strategy already constructed and the pack IDs ready to re-apply.
+struct UpdateScopeResolver {
+    let environment: Environment
+    let output: CLIOutput
+
+    struct ScopeRun {
+        let label: String
+        let strategy: any SyncStrategy
+        let configuredPackIDs: Set<String>
+        let excludedComponents: [String: Set<String>]
+        let isGlobal: Bool
+        /// The project root path. `nil` for the global scope.
+        let projectPath: URL?
+    }
+
+    enum Filter {
+        case all
+        case globalOnly
+        case projectOnly
+        case everywhere
+    }
+
+    func resolve(filter: Filter, projectRoot: URL?, dryRun: Bool = false) throws -> [ScopeRun] {
+        let indexFile = ProjectIndex(path: environment.projectsIndexFile)
+        var indexData = try indexFile.load()
+
+        let pruned = indexFile.pruneStale(in: &indexData)
+        if !pruned.isEmpty {
+            output.dimmed("Pruned \(pruned.count) stale project entries from index.")
+            if !dryRun {
+                try indexFile.save(indexData)
+            }
+        }
+
+        var runs: [ScopeRun] = []
+
+        if filter != .projectOnly,
+           let run = try buildRun(
+               indexEntryPath: ProjectIndex.globalSentinel,
+               in: indexData,
+               strategy: GlobalSyncStrategy(environment: environment),
+               label: "Global (\(environment.claudeDirectory.path))",
+               isGlobal: true,
+               projectPath: nil
+           ) {
+            runs.append(run)
+        }
+
+        switch filter {
+        case .everywhere:
+            for entry in indexData.projects {
+                guard let projectURL = entry.url?.standardizedFileURL else { continue }
+                if let run = try buildRun(
+                    indexEntryPath: entry.path,
+                    in: indexData,
+                    strategy: ProjectSyncStrategy(projectPath: projectURL, environment: environment),
+                    label: "Project: \(entry.path)",
+                    isGlobal: false,
+                    projectPath: projectURL
+                ) {
+                    runs.append(run)
+                }
+            }
+        case .all, .projectOnly:
+            if let projectRoot,
+               let run = try buildRun(
+                   indexEntryPath: projectRoot.standardizedFileURL.path,
+                   in: indexData,
+                   strategy: ProjectSyncStrategy(projectPath: projectRoot, environment: environment),
+                   label: "Project (\(projectRoot.lastPathComponent))",
+                   isGlobal: false,
+                   projectPath: projectRoot
+               ) {
+                runs.append(run)
+            }
+        case .globalOnly:
+            break
+        }
+
+        return runs
+    }
+
+    private func buildRun(
+        indexEntryPath: String,
+        in indexData: ProjectIndex.IndexData,
+        strategy: any SyncStrategy,
+        label: String,
+        isGlobal: Bool,
+        projectPath: URL?
+    ) throws -> ScopeRun? {
+        let entry = indexData.projects.first { $0.path == indexEntryPath }
+        guard let entry, !entry.packs.isEmpty else { return nil }
+
+        let state = try ProjectState(stateFile: strategy.scope.stateFile)
+        let configured = state.configuredPacks
+        guard !configured.isEmpty else { return nil }
+
+        return ScopeRun(
+            label: label,
+            strategy: strategy,
+            configuredPackIDs: configured,
+            excludedComponents: state.allExcludedComponents,
+            isGlobal: isGlobal,
+            projectPath: projectPath
+        )
+    }
+}

--- a/Sources/mcs/Sync/UpdateScopeResolver.swift
+++ b/Sources/mcs/Sync/UpdateScopeResolver.swift
@@ -2,9 +2,10 @@ import Foundation
 
 /// Resolves which scopes `mcs update` should refresh.
 ///
-/// Reads `~/.mcs/projects.yaml` and the per-scope state files to enumerate every
-/// place that has configured packs. Returns one entry per scope to refresh, with
-/// the strategy already constructed and the pack IDs ready to re-apply.
+/// `ProjectState` is the source of truth for whether a scope has configured packs.
+/// `~/.mcs/projects.yaml` is consulted only for project discovery (`.everywhere`)
+/// and for stale-entry pruning, since the index write in sync is best-effort and
+/// can lag behind state on a partial failure.
 struct UpdateScopeResolver {
     let environment: Environment
     let output: CLIOutput
@@ -42,8 +43,6 @@ struct UpdateScopeResolver {
 
         if filter != .projectOnly,
            let run = try buildRun(
-               indexEntryPath: ProjectIndex.globalSentinel,
-               in: indexData,
                strategy: GlobalSyncStrategy(environment: environment),
                label: "Global (\(environment.claudeDirectory.path))",
                isGlobal: true,
@@ -57,8 +56,6 @@ struct UpdateScopeResolver {
             for entry in indexData.projects {
                 guard let projectURL = entry.url?.standardizedFileURL else { continue }
                 if let run = try buildRun(
-                    indexEntryPath: entry.path,
-                    in: indexData,
                     strategy: ProjectSyncStrategy(projectPath: projectURL, environment: environment),
                     label: "Project: \(entry.path)",
                     isGlobal: false,
@@ -70,8 +67,6 @@ struct UpdateScopeResolver {
         case .all, .projectOnly:
             if let projectRoot,
                let run = try buildRun(
-                   indexEntryPath: projectRoot.standardizedFileURL.path,
-                   in: indexData,
                    strategy: ProjectSyncStrategy(projectPath: projectRoot, environment: environment),
                    label: "Project (\(projectRoot.lastPathComponent))",
                    isGlobal: false,
@@ -87,16 +82,11 @@ struct UpdateScopeResolver {
     }
 
     private func buildRun(
-        indexEntryPath: String,
-        in indexData: ProjectIndex.IndexData,
         strategy: any SyncStrategy,
         label: String,
         isGlobal: Bool,
         projectPath: URL?
     ) throws -> ScopeRun? {
-        let entry = indexData.projects.first { $0.path == indexEntryPath }
-        guard let entry, !entry.packs.isEmpty else { return nil }
-
         let state = try ProjectState(stateFile: strategy.scope.stateFile)
         let configured = state.configuredPacks
         guard !configured.isEmpty else { return nil }

--- a/Tests/MCSTests/UpdateScopeResolverTests.swift
+++ b/Tests/MCSTests/UpdateScopeResolverTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+@testable import mcs
+import Testing
+
+struct UpdateScopeResolverTests {
+    private func setup(
+        globalPacks: [String] = [],
+        projectPacks: [String]? = nil
+    ) throws -> (home: URL, project: URL, env: Environment) {
+        let home = try makeGlobalTmpDir(label: "update-resolver")
+        let project = home.appendingPathComponent("test-project")
+        try FileManager.default.createDirectory(
+            at: project.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: project.appendingPathComponent(Constants.FileNames.claudeDirectory),
+            withIntermediateDirectories: true
+        )
+
+        let env = Environment(home: home)
+
+        var indexData = ProjectIndex.IndexData()
+        let indexFile = ProjectIndex(path: env.projectsIndexFile)
+
+        if !globalPacks.isEmpty {
+            indexFile.upsert(
+                projectPath: ProjectIndex.globalSentinel,
+                packIDs: globalPacks,
+                in: &indexData
+            )
+            var globalState = try ProjectState(stateFile: env.globalStateFile)
+            for pack in globalPacks {
+                globalState.recordPack(pack)
+            }
+            try globalState.save()
+        }
+
+        if let projectPacks {
+            indexFile.upsert(
+                projectPath: project.standardizedFileURL.path,
+                packIDs: projectPacks,
+                in: &indexData
+            )
+            var projectState = try ProjectState(projectRoot: project)
+            for pack in projectPacks {
+                projectState.recordPack(pack)
+            }
+            try projectState.save()
+        }
+
+        try indexFile.save(indexData)
+        return (home, project, env)
+    }
+
+    @Test("Empty index returns no scopes")
+    func emptyIndex() throws {
+        let home = try makeGlobalTmpDir(label: "update-resolver-empty")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .all, projectRoot: nil)
+        #expect(runs.isEmpty)
+    }
+
+    @Test("Global-only configured returns one global run")
+    func globalOnly() throws {
+        let (home, _, env) = try setup(globalPacks: ["pack-a"])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .all, projectRoot: nil)
+        #expect(runs.count == 1)
+        #expect(runs[0].isGlobal)
+        #expect(runs[0].configuredPackIDs == ["pack-a"])
+    }
+
+    @Test("Both scopes return two runs in global → project order")
+    func bothScopes() throws {
+        let (home, project, env) = try setup(
+            globalPacks: ["pack-a"],
+            projectPacks: ["pack-b"]
+        )
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .all, projectRoot: project)
+        #expect(runs.count == 2)
+        #expect(runs[0].isGlobal)
+        #expect(runs[0].configuredPackIDs == ["pack-a"])
+        #expect(!runs[1].isGlobal)
+        #expect(runs[1].configuredPackIDs == ["pack-b"])
+        #expect(runs[1].projectPath?.standardizedFileURL == project.standardizedFileURL)
+    }
+
+    @Test("Filter .globalOnly excludes the project scope")
+    func filterGlobalOnly() throws {
+        let (home, project, env) = try setup(
+            globalPacks: ["pack-a"],
+            projectPacks: ["pack-b"]
+        )
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .globalOnly, projectRoot: project)
+        #expect(runs.count == 1)
+        #expect(runs[0].isGlobal)
+    }
+
+    @Test("Filter .projectOnly excludes the global scope")
+    func filterProjectOnly() throws {
+        let (home, project, env) = try setup(
+            globalPacks: ["pack-a"],
+            projectPacks: ["pack-b"]
+        )
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .projectOnly, projectRoot: project)
+        #expect(runs.count == 1)
+        #expect(!runs[0].isGlobal)
+        #expect(runs[0].configuredPackIDs == ["pack-b"])
+    }
+
+    @Test("Project not in index returns no project run")
+    func projectNotInIndex() throws {
+        let (home, project, env) = try setup(globalPacks: ["pack-a"])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .all, projectRoot: project)
+        #expect(runs.count == 1)
+        #expect(runs[0].isGlobal)
+    }
+
+    @Test("Filter .everywhere returns global plus every project in the index")
+    func everywhereFansOut() throws {
+        let home = try makeGlobalTmpDir(label: "update-resolver-everywhere")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        var indexData = ProjectIndex.IndexData()
+        let indexFile = ProjectIndex(path: env.projectsIndexFile)
+        indexFile.upsert(projectPath: ProjectIndex.globalSentinel, packIDs: ["pack-a"], in: &indexData)
+
+        let projectA = home.appendingPathComponent("proj-a")
+        let projectB = home.appendingPathComponent("proj-b")
+        for project in [projectA, projectB] {
+            try FileManager.default.createDirectory(
+                at: project.appendingPathComponent(Constants.FileNames.claudeDirectory),
+                withIntermediateDirectories: true
+            )
+            indexFile.upsert(
+                projectPath: project.standardizedFileURL.path,
+                packIDs: ["pack-b"],
+                in: &indexData
+            )
+            var state = try ProjectState(projectRoot: project)
+            state.recordPack("pack-b")
+            try state.save()
+        }
+        var globalState = try ProjectState(stateFile: env.globalStateFile)
+        globalState.recordPack("pack-a")
+        try globalState.save()
+        try indexFile.save(indexData)
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .everywhere, projectRoot: nil)
+        #expect(runs.count == 3)
+        #expect(runs[0].isGlobal)
+        let projectRunPaths = Set(runs.dropFirst().compactMap { $0.projectPath?.standardizedFileURL.path })
+        #expect(projectRunPaths == [projectA.standardizedFileURL.path, projectB.standardizedFileURL.path])
+    }
+
+    @Test("Stale project entries are pruned from the index")
+    func staleEntriesPruned() throws {
+        let home = try makeGlobalTmpDir(label: "update-resolver-stale")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        var indexData = ProjectIndex.IndexData()
+        let indexFile = ProjectIndex(path: env.projectsIndexFile)
+        indexFile.upsert(
+            projectPath: "/nonexistent/path/to/project",
+            packIDs: ["pack-x"],
+            in: &indexData
+        )
+        try indexFile.save(indexData)
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .all, projectRoot: nil)
+        #expect(runs.isEmpty)
+
+        let reloaded = try indexFile.load()
+        #expect(reloaded.projects.isEmpty)
+    }
+}

--- a/Tests/MCSTests/UpdateScopeResolverTests.swift
+++ b/Tests/MCSTests/UpdateScopeResolverTests.swift
@@ -195,4 +195,42 @@ struct UpdateScopeResolverTests {
         let reloaded = try indexFile.load()
         #expect(reloaded.projects.isEmpty)
     }
+
+    @Test("Dry-run resolve does not rewrite the pruned index to disk")
+    func dryRunDoesNotPruneOnDisk() throws {
+        let home = try makeGlobalTmpDir(label: "update-resolver-stale-dry")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        let stalePath = "/nonexistent/path/to/project"
+        var indexData = ProjectIndex.IndexData()
+        let indexFile = ProjectIndex(path: env.projectsIndexFile)
+        indexFile.upsert(projectPath: stalePath, packIDs: ["pack-x"], in: &indexData)
+        try indexFile.save(indexData)
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .all, projectRoot: nil, dryRun: true)
+        #expect(runs.isEmpty)
+
+        let reloaded = try indexFile.load()
+        #expect(reloaded.projects.count == 1)
+        #expect(reloaded.projects.first?.path == stalePath)
+    }
+
+    @Test("ProjectState is the source of truth — index entry is not required")
+    func stateOverridesMissingIndexEntry() throws {
+        let home = try makeGlobalTmpDir(label: "update-resolver-no-index")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let env = Environment(home: home)
+
+        var globalState = try ProjectState(stateFile: env.globalStateFile)
+        globalState.recordPack("pack-a")
+        try globalState.save()
+
+        let resolver = UpdateScopeResolver(environment: env, output: CLIOutput(colorsEnabled: false))
+        let runs = try resolver.resolve(filter: .all, projectRoot: nil)
+        #expect(runs.count == 1)
+        #expect(runs[0].isGlobal)
+        #expect(runs[0].configuredPackIDs == ["pack-a"])
+    }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ Before modifying files with user content (e.g., `CLAUDE.local.md`), a timestampe
 
 ### Lockfile (`Core/Lockfile.swift`)
 
-`mcs.lock.yaml` pins pack commits for reproducible builds. Generation is **opt-in** (default off) — enable persistently with `mcs config set generate-lockfile true` or write once with `mcs sync --update`. Tri-state on `generate-lockfile`: `true` writes on every sync; `false` is fully silent (explicit opt-out); `nil` (never configured) reports SHA drift against a pre-existing lockfile so users upgrading from the auto-generation era see their stale lockfile. Used with `--lock` to checkout pinned commits.
+`mcs.lock.yaml` pins pack commits for reproducible builds. Generation is **opt-in** (default off) — enable persistently with `mcs config set generate-lockfile true` or write once with the deprecated `mcs sync --update`. Tri-state on `generate-lockfile`: `true` writes on every sync; `false` is fully silent (explicit opt-out); `nil` (never configured) reports SHA drift against a pre-existing lockfile so users upgrading from the auto-generation era see their stale lockfile. Used with `--lock` to checkout pinned commits. `mcs update` respects the config (writes only when `true`) and never force-writes the way `--update` does.
 
 ### ClaudeIntegration (`Core/ClaudeIntegration.swift`)
 
@@ -341,7 +341,7 @@ The command (`Commands/ExportCommand.swift`) is a read-only `ParsableCommand` (n
 | **Non-Destructive** | User content in `CLAUDE.local.md` is preserved via `<!-- mcs:begin/end -->` section markers. Content outside markers is never touched. |
 | **Convergent** | Deselected packs are fully cleaned up — MCP servers removed, project files deleted, template sections stripped, settings keys cleaned. No orphaned artifacts. |
 | **Trust Verification** | Pack scripts are SHA-256 hashed at `mcs pack add` time and verified at load time. Modified scripts are detected and the user is prompted to re-trust before proceeding. Local packs skip verification since scripts change during development. |
-| **Lockfile (opt-in)** | `mcs.lock.yaml` pins pack commits for reproducible environments. Generation is off by default; enable with `mcs config set generate-lockfile true` or write once with `mcs sync --update`. Explicit `generate-lockfile: false` is silent; only the never-configured `nil` state surfaces drift warnings against a stale pre-existing lockfile. Use `--lock` to check out pinned versions from an existing lockfile. |
+| **Lockfile (opt-in)** | `mcs.lock.yaml` pins pack commits for reproducible environments. Generation is off by default; enable with `mcs config set generate-lockfile true` or write once with the deprecated `mcs sync --update`. Explicit `generate-lockfile: false` is silent; only the never-configured `nil` state surfaces drift warnings against a stale pre-existing lockfile. Use `--lock` to check out pinned versions from an existing lockfile. `mcs update` honours `generate-lockfile` and never force-writes. |
 
 ## Concurrency Model
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,9 +26,43 @@ mcs sync --update                # Fetch latest and write/update mcs.lock.yaml (
 | `--customize` | Per-pack component selection (deselect individual components). |
 | `--global` | Sync global-scope components (brew packages, plugins, MCP servers to `~/.claude/`). |
 | `--lock` | Check out the commits pinned in `mcs.lock.yaml`. |
-| `--update` | Fetch latest pack versions and write/update `mcs.lock.yaml`. Lockfile generation is opt-in; this flag forces a write for the current run regardless of the `generate-lockfile` config. |
+| `--update` | **Deprecated** — use `mcs update` instead. Fetches latest pack versions and force-writes `mcs.lock.yaml` regardless of the `generate-lockfile` config. |
 
 `mcs sync` is also the default command — running `mcs` alone is equivalent to `mcs sync`.
+
+## `mcs update`
+
+Refresh already-configured packs across every scope they're installed in. Fetches the latest pack contents (with trust verification) and re-applies the existing pack set in both the global scope and the current project's scope.
+
+```bash
+mcs update                       # Refresh all configured packs in every scope (global + current project)
+mcs update --pack <name>         # Only refresh specific pack(s) (repeatable)
+mcs update --global              # Only refresh the global scope
+mcs update --project             # Only refresh the current project's scope
+mcs update --all-projects        # Refresh global + every project in the index (machine-wide)
+mcs update --dry-run             # Preview without making changes
+```
+
+| Flag | Description |
+|------|-------------|
+| `[path]` | Project directory (defaults to current directory) |
+| `--pack <name>` | Limit the update to specific pack(s). Repeatable. Must be a pack already configured in at least one scope. |
+| `--global` | Only refresh the global scope. Mutually exclusive with `--project` and `--all-projects`. |
+| `--project` | Only refresh the current project's scope. Mutually exclusive with `--global` and `--all-projects`. |
+| `--all-projects` | Refresh the global scope plus every project tracked in `~/.mcs/projects.yaml`. Asks for confirmation in interactive mode and lists the affected projects first. Mutually exclusive with `--global` and `--project`. |
+| `--dry-run` | Preview changes without writing any files. |
+
+**About `--all-projects`:** this fans out machine-wide, running each pack's `configureProject` hook with the corresponding project as cwd. Uncommitted changes in those projects to managed files (settings, hooks, skills) may be overwritten. Always interactive-confirm in a terminal; pair with `--dry-run` first if unsure.
+
+**Differences from `mcs sync`:**
+
+- **Refresh-only** — does not add or remove packs. Use `mcs sync` to change the configured set.
+- **Multi-scope by default** — when configured packs exist in both global and project scopes, both are refreshed in one command (this was the original pain point that motivated the verb).
+- **Lockfile is gated by config** — `mcs update` writes `mcs.lock.yaml` only when `generate-lockfile: true`. Drift is reported when the key is unset and a lockfile is present (the upgrade nudge). This is intentionally different from the deprecated `mcs sync --update`, which force-writes the lockfile regardless of config.
+
+**Trust prompts:** when a pack's scripts have changed, `mcs update` prompts for trust. Denying the prompt skips the pack for this run (the registry stays at the old SHA, and the pack is excluded from re-apply so untrusted scripts don't auto-install). The prompt re-fires on the next `mcs update` run.
+
+**Prompt value reuse:** unlike `mcs sync`, `mcs update` does not show the interactive *"Reuse these values? [Y/n]"* gate when a pack's prompts already have stored answers. Refresh implies "keep what I have," so existing values are reused silently. **New** prompts introduced by a pack update still execute normally. To revisit stored values, use `mcs sync` (answer "No" at the gate to re-enter values one by one, with the existing answer as the default) or `mcs sync --customize` (always re-asks every prompt, no gate).
 
 ## `mcs pack`
 
@@ -72,8 +106,10 @@ mcs pack list                    # List registered packs with status
 
 ### `mcs pack update [name]`
 
+> **Deprecated.** Use [`mcs update`](#mcs-update) instead — it fetches latest pack contents *and* re-applies them across every configured scope in one step. `mcs pack update` only refreshes the local pack checkout without applying the changes anywhere.
+
 ```bash
-mcs pack update [name]           # Update pack(s) to latest version
+mcs pack update [name]           # Update pack(s) to latest version (no re-apply)
 ```
 
 Fetches the latest commits from the remote and updates the local checkout. Local packs are skipped (they are read in-place and pick up changes automatically).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,7 +36,6 @@ Refresh already-configured packs across every scope they're installed in. Fetche
 
 ```bash
 mcs update                       # Refresh all configured packs in every scope (global + current project)
-mcs update --pack <name>         # Only refresh specific pack(s) (repeatable)
 mcs update --global              # Only refresh the global scope
 mcs update --project             # Only refresh the current project's scope
 mcs update --all-projects        # Refresh global + every project in the index (machine-wide)
@@ -46,11 +45,12 @@ mcs update --dry-run             # Preview without making changes
 | Flag | Description |
 |------|-------------|
 | `[path]` | Project directory (defaults to current directory) |
-| `--pack <name>` | Limit the update to specific pack(s). Repeatable. Must be a pack already configured in at least one scope. |
 | `--global` | Only refresh the global scope. Mutually exclusive with `--project` and `--all-projects`. |
 | `--project` | Only refresh the current project's scope. Mutually exclusive with `--global` and `--all-projects`. |
 | `--all-projects` | Refresh the global scope plus every project tracked in `~/.mcs/projects.yaml`. Asks for confirmation in interactive mode and lists the affected projects first. Mutually exclusive with `--global` and `--project`. |
 | `--dry-run` | Preview changes without writing any files. |
+
+`mcs update` always refreshes the full configured set of every selected scope. To advance a single pack's registry pointer without applying anywhere, use [`mcs pack update <name>`](#mcs-pack-update-name).
 
 **About `--all-projects`:** this fans out machine-wide, running each pack's `configureProject` hook with the corresponding project as cwd. Uncommitted changes in those projects to managed files (settings, hooks, skills) may be overwritten. Always interactive-confirm in a terminal; pair with `--dry-run` first if unsure.
 
@@ -106,13 +106,13 @@ mcs pack list                    # List registered packs with status
 
 ### `mcs pack update [name]`
 
-> **Deprecated.** Use [`mcs update`](#mcs-update) instead — it fetches latest pack contents *and* re-applies them across every configured scope in one step. `mcs pack update` only refreshes the local pack checkout without applying the changes anywhere.
-
 ```bash
-mcs pack update [name]           # Update pack(s) to latest version (no re-apply)
+mcs pack update [name]           # Update pack(s) to latest version (registry only, no re-apply)
 ```
 
 Fetches the latest commits from the remote and updates the local checkout. Local packs are skipped (they are read in-place and pick up changes automatically).
+
+This is a low-level fetch — useful for pack authors testing upstream changes without applying them, or in CI workflows that handle the apply step separately. For most users, [`mcs update`](#mcs-update) is the right command: it does the same fetch *and* re-applies across every configured scope.
 
 ### `mcs pack validate [source]`
 


### PR DESCRIPTION
## Summary

Users with packs configured in both global and project scopes had to run two separate commands to pick up upstream pack updates ("I ran sync, why is my other scope still stale?"). This adds a single `mcs update` verb that fetches the latest pack contents and re-applies the existing configured set across every scope the user is in.

## Changes

- `mcs update` refreshes configured packs across the global scope and the current project's scope in one invocation, with trust prompts handled by the existing pack-update pipeline.
- `--global`, `--project`, and `--dry-run` scope the refresh; `--all-projects` fans out to every project recorded in the project index after listing them and asking for interactive confirmation.
- The interactive "Reuse these values?" gate is bypassed during update so prior prompt answers are reused silently. New prompts introduced by a pack update still execute. To revisit stored values, users keep using `mcs sync` (Y/n gate) or `mcs sync --customize`.
- Trust-denied packs are skipped from re-apply for that run so newly-fetched untrusted scripts cannot auto-install; the prompt re-fires on the next `mcs update`.
- Lockfile generation honours `generate-lockfile` instead of force-writing the way `--update` does, and runs only on project scopes.
- Re-apply and lockfile phases run best-effort: a single scope's failure no longer aborts the rest; the command surfaces failed labels and exits non-zero only if any failed.
- Per-pack registry-update success messages are buffered until after the registry persist; a failed save lists the unpersisted updates instead of leaving misleading "X → Y" messages on screen.
- Outside a project (or inside an unconfigured project), the command refreshes only the global scope and surfaces a hint suggesting `cd` or `mcs sync`.
- `mcs sync --update` prints a one-line deprecation warning and continues to work for one release. The "available pack updates" hint shown by sync/doctor/check-updates and the SessionStart hook now points at `mcs update`.
- The project-index stale-entry pruning runs only in `--all-projects` mode (the only mode that consumes the result) and does not write to disk during `--dry-run`.
- `mcs pack update` is **not** deprecated — it stays as the surgical "registry-only fetch" verb for pack authors and CI.

## Test plan

- Configure two packs, one in the global scope and one in a project, then advance both upstream and run `mcs update` from the project — expect both scopes to refresh in a single invocation with no second command needed.
- Run `mcs update --dry-run` from the same project — expect a preview only; the project index is not rewritten even if it contained stale entries.
- Set `generate-lockfile` to its three states (`true`, `false`, unset) and run `mcs update` in each — expect lockfile written, silent skip, and a drift warning respectively.
- Deny the trust prompt for a pack with new scripts during `mcs update` — expect the pack to be skipped from re-apply that run, with the prompt re-firing on the next invocation.
- Run `mcs update --all-projects` interactively — expect a list including both the global scope and each project, then a default-No confirmation; running it again under `--dry-run` should preview without writing.
- Run `mcs sync --update` — expect the deprecation warning followed by its existing behavior.
- Run `mcs update --global ~/some/path` — expect a warning that the positional path is ignored under `--global`.

<details>
<summary>Checklist for engine changes</summary>

- [x] Integration tests updated for new features (resolver-level tests for the new scope filter cases)
- [x] Docs updated if behavior changed (`CLAUDE.md`, `docs/cli.md`, `docs/architecture.md`)

</details>