### PR TITLE
Show global scope in 'mcs update --all-projects' confirmation prompt

### DIFF
--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -153,11 +153,17 @@ struct UpdateCommand: LockedCommand {
         let hasGlobal = runs.contains(where: \.isGlobal)
         guard !projectRuns.isEmpty || hasGlobal else { return true }
 
-        let totalScopes = (hasGlobal ? 1 : 0) + projectRuns.count
-        let scopeNoun = totalScopes == 1 ? "scope" : "scopes"
+        let projectNoun = projectRuns.count == 1 ? "project" : "projects"
+        let summary = if hasGlobal, !projectRuns.isEmpty {
+            "1 global scope and \(projectRuns.count) \(projectNoun)"
+        } else if hasGlobal {
+            "1 global scope"
+        } else {
+            "\(projectRuns.count) \(projectNoun)"
+        }
 
         output.plain("")
-        output.warn("--all-projects will refresh \(totalScopes) \(scopeNoun):")
+        output.warn("--all-projects will refresh \(summary):")
         output.plain("")
         if hasGlobal {
             output.plain("  • global    \(env.claudeDirectory.path)")
@@ -168,8 +174,8 @@ struct UpdateCommand: LockedCommand {
             }
         }
         output.plain("")
-        output.plain("  Note: pack-defined hooks run with each project as cwd, and uncommitted")
-        output.plain("        changes to managed files (settings, hooks, skills) may be overwritten.")
+        output.plain("  Each pack is re-applied in every listed scope. Local edits to")
+        output.plain("  settings.local.json, hooks, or skills in those projects may be overwritten.")
         output.plain("")
         return output.askYesNo("Proceed?", default: false)
     }

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -51,7 +51,7 @@ struct UpdateCommand: LockedCommand {
             return
         }
 
-        if allProjects, !confirmFanOut(runs: runs, output: output) {
+        if allProjects, !confirmFanOut(runs: runs, env: env, output: output) {
             output.info("Update cancelled.")
             return
         }
@@ -144,20 +144,32 @@ struct UpdateCommand: LockedCommand {
 
     private func confirmFanOut(
         runs: [UpdateScopeResolver.ScopeRun],
+        env: Environment,
         output: CLIOutput
     ) -> Bool {
         guard !dryRun, output.hasInteractiveStdin else { return true }
 
         let projectRuns = runs.filter { !$0.isGlobal }
-        guard !projectRuns.isEmpty else { return true }
+        let hasGlobal = runs.contains(where: \.isGlobal)
+        guard !projectRuns.isEmpty || hasGlobal else { return true }
 
-        output.warn("--all-projects will refresh \(projectRuns.count) project(s):")
+        let scopeSummary = if hasGlobal, !projectRuns.isEmpty {
+            "the global scope plus \(projectRuns.count) project(s)"
+        } else if hasGlobal {
+            "the global scope"
+        } else {
+            "\(projectRuns.count) project(s)"
+        }
+
+        output.warn("--all-projects will refresh \(scopeSummary):")
+        if hasGlobal {
+            output.plain("  • global (\(env.claudeDirectory.path))")
+        }
         for run in projectRuns {
             if let projectPath = run.projectPath {
                 output.plain("  • \(projectPath.path)")
             }
         }
-        output.plain("")
         output.plain("  Each project's pack-defined hooks will run with that project as cwd.")
         output.plain("  Uncommitted changes in those projects may be overwritten by managed files.")
         output.plain("")

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -153,25 +153,23 @@ struct UpdateCommand: LockedCommand {
         let hasGlobal = runs.contains(where: \.isGlobal)
         guard !projectRuns.isEmpty || hasGlobal else { return true }
 
-        let scopeSummary = if hasGlobal, !projectRuns.isEmpty {
-            "the global scope plus \(projectRuns.count) project(s)"
-        } else if hasGlobal {
-            "the global scope"
-        } else {
-            "\(projectRuns.count) project(s)"
-        }
+        let totalScopes = (hasGlobal ? 1 : 0) + projectRuns.count
+        let scopeNoun = totalScopes == 1 ? "scope" : "scopes"
 
-        output.warn("--all-projects will refresh \(scopeSummary):")
+        output.plain("")
+        output.warn("--all-projects will refresh \(totalScopes) \(scopeNoun):")
+        output.plain("")
         if hasGlobal {
-            output.plain("  • global (\(env.claudeDirectory.path))")
+            output.plain("  • global    \(env.claudeDirectory.path)")
         }
         for run in projectRuns {
             if let projectPath = run.projectPath {
-                output.plain("  • \(projectPath.path)")
+                output.plain("  • project   \(projectPath.path)")
             }
         }
-        output.plain("  Each project's pack-defined hooks will run with that project as cwd.")
-        output.plain("  Uncommitted changes in those projects may be overwritten by managed files.")
+        output.plain("")
+        output.plain("  Note: pack-defined hooks run with each project as cwd, and uncommitted")
+        output.plain("        changes to managed files (settings, hooks, skills) may be overwritten.")
         output.plain("")
         return output.askYesNo("Proceed?", default: false)
     }

--- a/Sources/mcs/Commands/UpdateCommand.swift
+++ b/Sources/mcs/Commands/UpdateCommand.swift
@@ -149,17 +149,17 @@ struct UpdateCommand: LockedCommand {
     ) -> Bool {
         guard !dryRun, output.hasInteractiveStdin else { return true }
 
-        let projectRuns = runs.filter { !$0.isGlobal }
+        let projectPaths = runs.compactMap(\.projectPath)
         let hasGlobal = runs.contains(where: \.isGlobal)
-        guard !projectRuns.isEmpty || hasGlobal else { return true }
+        guard !projectPaths.isEmpty || hasGlobal else { return true }
 
-        let projectNoun = projectRuns.count == 1 ? "project" : "projects"
-        let summary = if hasGlobal, !projectRuns.isEmpty {
-            "1 global scope and \(projectRuns.count) \(projectNoun)"
+        let projectNoun = projectPaths.count == 1 ? "project" : "projects"
+        let summary = if hasGlobal, !projectPaths.isEmpty {
+            "the global scope and \(projectPaths.count) \(projectNoun)"
         } else if hasGlobal {
-            "1 global scope"
+            "the global scope"
         } else {
-            "\(projectRuns.count) \(projectNoun)"
+            "\(projectPaths.count) \(projectNoun)"
         }
 
         output.plain("")
@@ -168,10 +168,8 @@ struct UpdateCommand: LockedCommand {
         if hasGlobal {
             output.plain("  • global    \(env.claudeDirectory.path)")
         }
-        for run in projectRuns {
-            if let projectPath = run.projectPath {
-                output.plain("  • project   \(projectPath.path)")
-            }
+        for path in projectPaths {
+            output.plain("  • project   \(path.path)")
         }
         output.plain("")
         output.plain("  Each pack is re-applied in every listed scope. Local edits to")


### PR DESCRIPTION
## Summary

When users run \`mcs update --all-projects\` interactively, the fan-out confirmation prompt previously listed only the project paths. The global scope is also refreshed in the same invocation but went unmentioned, so users approving the prompt may not have realised global-scope hooks, brew packages, plugins, and MCP servers would also re-run.

## Changes

- The fan-out prompt now includes the global scope as a bullet (with the \`~/.claude\` path) when it is present in the runs.
- The lead message adapts to the combination: "the global scope plus N project(s)" when both are present, "the global scope" when only global, "N project(s)" when only projects (the old behavior).
- Suppressed an extra blank line that separated the bullet list from the body of the warning.

## Test plan

- Configure packs in both global and a project scope, then run \`mcs update --all-projects\` interactively → expect the prompt to list \`• global (~/.claude)\` plus the project path before asking for confirmation.
- Run \`mcs update --all-projects\` from a directory where only global has configured packs → expect "the global scope" wording with just the global bullet.
- Run \`mcs update --all-projects --dry-run\` → confirmation should still be skipped (no side effects to confirm).