### PR TITLE
Disable wrapIfStatementBodies to match the repo's inline style

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -2,4 +2,4 @@
 --indent 4
 --ifdef noindent
 --exclude .build,.swiftpm
---disable wrapMultilineStatementBraces
+--disable wrapMultilineStatementBraces,wrapIfStatementBodies


### PR DESCRIPTION
## Summary

A clean `main` currently fails `swiftformat --lint --strict .` on 20 files, 109 violations, all from a single rule. Newer SwiftFormat releases wrap single-line `if x { return y }` bodies onto three lines; this codebase writes them inline throughout. Nothing in the repo changed — the lint job installs SwiftFormat unpinned (`brew install` + `brew upgrade`), so a new release moved the goalposts.

Disabling the rule states the existing style in config, which keeps the check stable across future SwiftFormat upgrades. The alternative, pinning the tool version, would freeze the repo on an old release and still leave contributors' local `swiftformat` runs rewriting unrelated lines in every file they touch.

## Changes

- Adds `wrapIfStatementBodies` to the existing `--disable` list in `.swiftformat`, alongside `wrapMultilineStatementBraces`. Combined onto one comma-separated directive so there is no ambiguity about whether a second `--disable` line accumulates or overrides.

## Test plan

- [x] `swift test` passes locally
- [x] `swiftformat --lint .` and `swiftlint` pass without violations — `0/138 files require formatting` (was 20), SwiftLint `0 violations`
- [x] Affected commands verified with a real pack — N/A, config-only change with no runtime effect